### PR TITLE
Use NoDrop to fix panic safety issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 matrix:
   include:
     - rust: stable
+    - rust: beta
     - rust: nightly
     - rust: nightly
       env:
@@ -11,6 +12,7 @@ script:
   - |
       [ -z "$NODROP_FEATURES" ] && cargo build --verbose --features "$FEATURES"
       [ -z "$NODROP_FEATURES" ] && cargo test --verbose --features "$FEATURES"
+      [ -z "$NODROP_FEATURES" ] && cargo test --release --verbose --features "$FEATURES"
       [ -z "$NODROP_FEATURES" ] && cargo bench --verbose --features "$FEATURES" -- --test
       [ -z "$NODROP_FEATURES" ] && cargo doc --verbose --features "$FEATURES"
       cargo test --verbose --manifest-path=nodrop/Cargo.toml --features "$NODROP_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["stack", "vector", "array", "container", "data-structure"]
 [dependencies.odds]
 version = "0.2"
 
-[dev-dependencies]
-nodrop = "0.1"
-
+[dependencies.nodrop]
+version = "0.1.4"
+path = "nodrop"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ subst: $(DOCCRATES)
 
 mkdocs: Cargo.toml
 	cargo doc --features=$(FEATURES)
-	cargo doc -p nodrop
 	rm -rf ./doc
 	cp -r ./target/doc ./doc
 	-cat ./custom.css >> doc/main.css

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -130,12 +130,12 @@ fn test_compact_size() {
     // 4 elements size + 1 len + 1 enum tag + [1 drop flag]
     type ByteArray = ArrayVec<[u8; 4]>;
     println!("{}", mem::size_of::<ByteArray>());
-    assert!(mem::size_of::<ByteArray>() <= 7);
+    assert!(mem::size_of::<ByteArray>() <= 8);
 
     // 12 element size + 1 enum tag + 3 padding + 1 len + 1 drop flag + 2 padding
     type QuadArray = ArrayVec<[u32; 3]>;
     println!("{}", mem::size_of::<QuadArray>());
-    assert!(mem::size_of::<QuadArray>() <= 20);
+    assert!(mem::size_of::<QuadArray>() <= 24);
 }
 
 #[test]
@@ -161,6 +161,37 @@ fn test_drain_oob() {
     let mut v = ArrayVec::from([0; 8]);
     v.pop();
     v.drain(0..8);
+}
+
+#[test]
+#[should_panic]
+fn test_drop_panic() {
+    struct DropPanic;
+
+    impl Drop for DropPanic {
+        fn drop(&mut self) {
+            panic!("drop");
+        }
+    }
+
+    let mut array = ArrayVec::<[DropPanic; 1]>::new();
+    array.push(DropPanic);
+}
+
+#[test]
+#[should_panic]
+fn test_drop_panic_into_iter() {
+    struct DropPanic;
+
+    impl Drop for DropPanic {
+        fn drop(&mut self) {
+            panic!("drop");
+        }
+    }
+
+    let mut array = ArrayVec::<[DropPanic; 1]>::new();
+    array.push(DropPanic);
+    array.into_iter();
 }
 
 #[test]


### PR DESCRIPTION
ArrayVec::drop was not panic safe — if there would be a panic during an
element's drop, the discriminant would never be set to Dropped, and the
array elements would potentially double drop.

Fix this by going back to the old NoDrop composition. The NoDrop struct
thas its own Drop impl, that will trigger too on panic during an element's
drop. This serves to make ArrayVec::drop panic safe.

Also tweak IntoIter::drop to make it panic safe: set inner ArrayVec's
length before dropping any elements.

Thank you to @Stebalien for reporting this bug and providing the
excellent testcases in this commit.

Using NoDrop expands ArrayVec to have two drop flags again, but this
is a temporary tradeoff, drop flags will eventually go away.

Fixes #3