### PR TITLE
WIP Specialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ default-features = false
 [features]
 default = ["std"]
 std = ["odds/std", "nodrop/std"]
+
+specialization = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,10 +202,8 @@ impl<A: Array> Len for CopyRepr<A> {
 impl<A: Array> FromArray for CopyRepr<A> {
     type Array = A;
     fn from_array(xs: A) -> Self {
-        unsafe {
-            CopyRepr {
-                xs: uninit::new(xs), len: Index::from(A::capacity())
-            }
+        CopyRepr {
+            xs: uninit::new(xs), len: Index::from(A::capacity())
         }
     }
     fn array_ref(&self) -> &Self::Array {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,20 @@ pub struct ArrayVec<A: Array> {
 trait Repr {
     type Item;
     type Array;
-    type Data: Default + DerefMut<Target=[Self::Item]> + Len + FromArray<Array=Self::Array>;
+    type Data: Clone + Default + DerefMut<Target=[Self::Item]> + Len + FromArray<Array=Self::Array>;
 }
+
+/*
+impl<A: Array> Copy for ArrayVec<A>
+    where A::Data: Copy
+    //where <A as Repr>::Data: Copy
+{ }
+*/
+
+impl<A: Copy + Repr + Array> Copy for ArrayVec<A>
+    where A::Data: Copy, <A as Array>::Item: Copy,
+    //where <A as Repr>::Data: Copy
+{ }
 
 trait Len {
     fn len(&self) -> usize;
@@ -154,6 +166,7 @@ impl<A: Copy + Array> Repr for A {
     type Data = CopyRepr<A>;
 }
 
+#[derive(Copy, Clone)]
 struct CopyRepr<A: Array> {
     xs: A,
     len: A::Index,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,15 +77,8 @@ pub struct ArrayVec<A: Array> {
 trait Repr {
     type Item;
     type Array;
-    type Data: Clone + Default + DerefMut<Target=[Self::Item]> + Len + FromArray<Array=Self::Array>;
+    type Data: Default + DerefMut<Target=[Self::Item]> + Len + FromArray<Array=Self::Array>;
 }
-
-/*
-impl<A: Array> Copy for ArrayVec<A>
-    where A::Data: Copy
-    //where <A as Repr>::Data: Copy
-{ }
-*/
 
 impl<A: Copy + Repr + Array> Copy for ArrayVec<A>
     where A::Data: Copy, <A as Array>::Item: Copy,

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -1,6 +1,5 @@
 
 use std::ops::{Deref, DerefMut};
-use odds::debug_assert_unreachable;
 
 /// repr(u8) - Make sure the non-nullable pointer optimization does not occur!
 #[repr(u8)]
@@ -8,10 +7,13 @@ use odds::debug_assert_unreachable;
 pub enum Uninit<T> {
     Alive(T),
     #[allow(dead_code)]
-    Dropped,
+    Void(Void),
 }
 
-pub unsafe fn new<T>(value: T) -> Uninit<T> {
+#[derive(Copy, Clone)]
+pub enum Void { }
+
+pub fn new<T>(value: T) -> Uninit<T> {
     Uninit::Alive(value)
 }
 
@@ -23,7 +25,7 @@ impl<T> Deref for Uninit<T> {
     fn deref(&self) -> &T {
         match *self {
             Uninit::Alive(ref inner) => inner,
-            _ => unsafe { debug_assert_unreachable() }
+            Uninit::Void(ref inner) => match *inner { /* unreachable */ }
         }
     }
 }
@@ -34,7 +36,7 @@ impl<T> DerefMut for Uninit<T> {
     fn deref_mut(&mut self) -> &mut T {
         match *self {
             Uninit::Alive(ref mut inner) => inner,
-            _ => unsafe { debug_assert_unreachable() }
+            Uninit::Void(ref inner) => match *inner { /* unreachable */ }
         }
     }
 }

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -1,0 +1,40 @@
+
+use std::ops::{Deref, DerefMut};
+use odds::debug_assert_unreachable;
+
+/// repr(u8) - Make sure the non-nullable pointer optimization does not occur!
+#[repr(u8)]
+#[derive(Copy, Clone)]
+pub enum Uninit<T> {
+    Alive(T),
+    #[allow(dead_code)]
+    Dropped,
+}
+
+pub unsafe fn new<T>(value: T) -> Uninit<T> {
+    Uninit::Alive(value)
+}
+
+impl<T> Deref for Uninit<T> {
+    type Target = T;
+
+    // Use type invariant, always Uninit::Alive.
+    #[inline]
+    fn deref(&self) -> &T {
+        match *self {
+            Uninit::Alive(ref inner) => inner,
+            _ => unsafe { debug_assert_unreachable() }
+        }
+    }
+}
+
+impl<T> DerefMut for Uninit<T> {
+    // Use type invariant, always Uninit::Alive.
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        match *self {
+            Uninit::Alive(ref mut inner) => inner,
+            _ => unsafe { debug_assert_unreachable() }
+        }
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -248,6 +248,14 @@ fn test_in_option() {
 }
 
 #[test]
+fn test_copy() {
+    let mut v = ArrayVec::from([1, 2, 3]);
+    let mut u = v;
+    v[0] = 0;
+    assert!(v != u);
+}
+
+#[test]
 fn test_into_inner_1() {
     let mut v = ArrayVec::from([1, 2]);
     v.pop();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -126,6 +126,8 @@ fn test_is_send_sync() {
     &data as &Send;
     &data as &Sync;
 }
+/*
+*/
 
 #[test]
 fn test_compact_size() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -247,10 +247,11 @@ fn test_in_option() {
     assert!(v.is_some());
 }
 
+#[cfg(feature = "specialization")]
 #[test]
 fn test_copy() {
     let mut v = ArrayVec::from([1, 2, 3]);
-    let mut u = v;
+    let u = v;
     v[0] = 0;
     assert!(v != u);
 }


### PR DESCRIPTION
Specialization allows special casing for Copy elements.

For Copy arrays, ArrayVec is Copy and does not need to overwrite itself in Drop.
