### PR TITLE
Support generic-array as arrayvec backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - rust: 1.2.0
     - rust: stable
       env:
+        - FEATURES="use_generic_array"
         - NODEFAULT=1
     - rust: beta
     - rust: nightly
@@ -15,7 +16,7 @@ matrix:
       - NODROP_FEATURES='use_needs_drop'
     - rust: nightly
       env:
-      - FEATURES='use_union'
+      - FEATURES='use_union use_generic_array'
       - NODROP_FEATURES='use_union'
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,12 @@ version = "0.1.8"
 path = "nodrop"
 default-features = false
 
+[dependencies.generic-array]
+version = "0.5.1"
+optional = true
+
 [features]
 default = ["std"]
 std = ["odds/std", "nodrop/std"]
 use_union = ["nodrop/use_union"]
+use_generic_array = ["generic-array"]

--- a/src/array.rs
+++ b/src/array.rs
@@ -19,6 +19,24 @@ pub trait Index : PartialEq + Copy {
     fn from(usize) -> Self;
 }
 
+#[cfg(feature = "use_generic_array")]
+unsafe impl<T, U> Array for ::generic_array::GenericArray<T, U>
+    where U: ::generic_array::ArrayLength<T>
+{
+    type Item = T;
+    type Index = usize;
+    fn as_ptr(&self) -> *const Self::Item {
+        (**self).as_ptr()
+    }
+    fn as_mut_ptr(&mut self) -> *mut Self::Item {
+        (**self).as_mut_ptr()
+    }
+    fn capacity() -> usize {
+        U::to_usize()
+    }
+
+}
+
 impl Index for u8 {
     #[inline(always)]
     fn to_usize(self) -> usize { self as usize }
@@ -31,6 +49,13 @@ impl Index for u16 {
     fn to_usize(self) -> usize { self as usize }
     #[inline(always)]
     fn from(ix: usize) ->  Self { ix as u16 }
+}
+
+impl Index for usize {
+    #[inline(always)]
+    fn to_usize(self) -> usize { self }
+    #[inline(always)]
+    fn from(ix: usize) ->  Self { ix }
 }
 
 macro_rules! fix_array_impl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,17 @@
 //!   - Requires Rust nightly channel
 //!   - Use the unstable feature untagged unions for the internal implementation,
 //!     which has reduced space overhead
+//!
+//! - `use_generic_array`
+//!   - Optional
+//!   - Depend on generic-array and allow using it just like a fixed
+//!     size array for ArrayVec storage.
 #![cfg_attr(not(feature="std"), no_std)]
 extern crate odds;
 extern crate nodrop;
+
+#[cfg(feature = "use_generic_array")]
+extern crate generic_array;
 
 #[cfg(not(feature="std"))]
 extern crate core as std;

--- a/tests/generic_array.rs
+++ b/tests/generic_array.rs
@@ -1,0 +1,23 @@
+#![cfg(feature = "use_generic_array")]
+
+extern crate arrayvec;
+#[macro_use]
+extern crate generic_array;
+
+use arrayvec::ArrayVec;
+
+use generic_array::GenericArray;
+
+use generic_array::typenum::U41;
+
+#[test]
+fn test_simple() {
+    let mut vec: ArrayVec<GenericArray<i32, U41>> = ArrayVec::new();
+
+    assert_eq!(vec.len(), 0);
+    assert_eq!(vec.capacity(), 41);
+    vec.extend(0..20);
+    assert_eq!(vec.len(), 20);
+    assert_eq!(&vec[..5], &[0, 1, 2, 3, 4]);
+}
+


### PR DESCRIPTION
I'm sorry, I never realized we could do this as an addition, without changing how arrayvec works.

This is awesome!

This adds generic-array as an optional dependency. When it is, you can use GenericArray as an arrayvec storage backing.