### PR TITLE
Use u8 field in the NoDrop Dropped variant

### DIFF
--- a/nodrop/src/lib.rs
+++ b/nodrop/src/lib.rs
@@ -42,7 +42,8 @@ mod imp {
     #[repr(u8)]
     enum Flag<T> {
         Alive(T),
-        Dropped,
+        // Dummy u8 field below, again to beat the enum layout opt
+        Dropped(u8),
     }
 
 
@@ -89,7 +90,7 @@ mod imp {
             if needs_drop::<T>() {
                 // inhibit drop
                 unsafe {
-                    ptr::write(&mut self.0, Flag::Dropped);
+                    ptr::write(&mut self.0, Flag::Dropped(0));
                 }
             }
         }


### PR DESCRIPTION
We need to ensure NoDrop<&T> and similar are not using the enum layout
optimization. Using an enum { Alive(T), Dropped(u8) } is a simple way to
do that. The NoDrop (non-unions version) was already always at least
1 byte large anyway.

Fixes soundness issue & test failure in recent nightly. This bug originates in nodrop and affected arrayvec too.