### PR TITLE
Add serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 env:
-  - FEATURES='serde'
+  - FEATURES='serde-1'
 matrix:
   include:
     - rust: 1.12.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 sudo: false
+env:
+  - FEATURES='serde'
 matrix:
   include:
     - rust: 1.12.0
@@ -15,7 +17,7 @@ matrix:
       - NODROP_FEATURES='use_needs_drop'
     - rust: nightly
       env:
-      - FEATURES='use_union'
+      - FEATURES='serde use_union'
       - NODROP_FEATURES='use_union'
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ version = "0.1.8"
 path = "nodrop"
 default-features = false
 
+[dependencies.serde]
+version = "1.0"
+optional = true
+default-features = false
+
+[dev-dependencies.serde_test]
+version = "1.0"
+
 [features]
 default = ["std"]
 std = ["odds/std", "nodrop/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ version = "1.0"
 default = ["std"]
 std = ["odds/std", "nodrop/std"]
 use_union = ["nodrop/use_union"]
+serde-1 = ["serde"]

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -351,7 +351,7 @@ impl<'de, A: Array<Item=u8>> Deserialize<'de> for ArrayString<A> {
             type Value = ArrayString<A>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "a string with no more than {} elements", A::capacity())
+                write!(formatter, "a string no more than {} bytes long", A::capacity())
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -14,7 +14,7 @@ use array::Index;
 use CapacityError;
 use odds::char::encode_utf8;
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 /// A string with a fixed capacity.
@@ -328,7 +328,7 @@ impl<A: Array<Item=u8>> Ord for ArrayString<A> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 impl<A: Array<Item=u8>> Serialize for ArrayString<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -337,7 +337,7 @@ impl<A: Array<Item=u8>> Serialize for ArrayString<A> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 impl<'de, A: Array<Item=u8>> Deserialize<'de> for ArrayString<A> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(not(feature="std"), no_std)]
 extern crate odds;
 extern crate nodrop;
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 extern crate serde;
 
 #[cfg(not(feature="std"))]
@@ -48,7 +48,7 @@ use std::any::Any; // core but unused
 
 use nodrop::NoDrop;
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 mod array;
@@ -826,7 +826,7 @@ impl<A: Array<Item=u8>> io::Write for ArrayVec<A> {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 impl<T: Serialize, A: Array<Item=T>> Serialize for ArrayVec<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -835,7 +835,7 @@ impl<T: Serialize, A: Array<Item=T>> Serialize for ArrayVec<A> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature="serde-1")]
 impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Deserialize<'de> for ArrayVec<A> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,7 +849,7 @@ impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Deserialize<'de> for ArrayVec<A
             type Value = ArrayVec<A>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "an array with no more than {} elements", A::capacity())
+                write!(formatter, "an array with no more than {} items", A::capacity())
             }
 
             fn visit_seq<SA>(self, mut seq: SA) -> Result<Self::Value, SA::Error>

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde")]
+#![cfg(feature = "serde-1")]
 extern crate arrayvec;
 extern crate serde_test;
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "serde")]
+extern crate arrayvec;
+extern crate serde_test;
+
+mod array_vec {
+    use arrayvec::ArrayVec;
+
+    use serde_test::{Token, assert_tokens};
+
+    #[test]
+    fn test_ser_de_empty() {
+        let vec = ArrayVec::<[u32; 0]>::new();
+
+        assert_tokens(&vec, &[
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+        ]);
+    }
+
+
+    #[test]
+    fn test_ser_de() {
+        let mut vec = ArrayVec::<[u32; 3]>::new();
+        vec.push(20);
+        vec.push(55);
+        vec.push(123);
+
+        assert_tokens(&vec, &[
+            Token::Seq { len: Some(3) },
+            Token::U32(20),
+            Token::U32(55),
+            Token::U32(123),
+            Token::SeqEnd,
+        ]);
+    }
+}
+
+mod array_string {
+    use arrayvec::ArrayString;
+
+    use serde_test::{Token, assert_tokens};
+
+    #[test]
+    fn test_ser_de_empty() {
+        let string = ArrayString::<[u8; 0]>::new();
+
+        assert_tokens(&string, &[
+            Token::Str(""),
+        ]);
+    }
+
+
+    #[test]
+    fn test_ser_de() {
+        let string = ArrayString::<[u8; 9]>::from("1234 abcd")
+            .expect("expected exact specified capacity to be enough");
+
+        assert_tokens(&string, &[
+            Token::Str("1234 abcd"),
+        ]);
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -5,7 +5,7 @@ extern crate serde_test;
 mod array_vec {
     use arrayvec::ArrayVec;
 
-    use serde_test::{Token, assert_tokens};
+    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
 
     #[test]
     fn test_ser_de_empty() {
@@ -33,12 +33,22 @@ mod array_vec {
             Token::SeqEnd,
         ]);
     }
+
+    #[test]
+    fn test_de_too_large() {
+        assert_de_tokens_error::<ArrayVec<[u32; 2]>>(&[
+            Token::Seq { len: Some(3) },
+            Token::U32(13),
+            Token::U32(42),
+            Token::U32(68),
+        ], "invalid length 3, expected an array with no more than 2 items");
+    }
 }
 
 mod array_string {
     use arrayvec::ArrayString;
 
-    use serde_test::{Token, assert_tokens};
+    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
 
     #[test]
     fn test_ser_de_empty() {
@@ -58,5 +68,12 @@ mod array_string {
         assert_tokens(&string, &[
             Token::Str("1234 abcd"),
         ]);
+    }
+
+    #[test]
+    fn test_de_too_large() {
+        assert_de_tokens_error::<ArrayString<[u8; 2]>>(&[
+            Token::Str("afd")
+        ], "invalid length 3, expected a string no more than 2 bytes long");
     }
 }


### PR DESCRIPTION
This implements serde support under the optional 'serde' feature, and adds unit tests to test said support.

Serde will be optionally included for runtime, but is unfortunately required for running tests - as cargo does not have support for optional dev-dependencies. `FEATURES="serde"` is added to the travis config, as serde-support tests will not run without it.

Fixes #54.