### PR TITLE
Add serde support to 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - rust: 1.2.0
     - rust: stable
       env:
-        - FEATURES="use_generic_array"
+        - FEATURES="use_generic_array serde"
         - NODEFAULT=1
     - rust: beta
     - rust: nightly
@@ -16,7 +16,7 @@ matrix:
       - NODROP_FEATURES='use_needs_drop'
     - rust: nightly
       env:
-      - FEATURES='use_union use_generic_array'
+      - FEATURES='use_union use_generic_array serde'
       - NODROP_FEATURES='use_union'
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,14 @@ default-features = false
 version = "0.5.1"
 optional = true
 
+[dependencies.serde]
+version = "1.0"
+optional = true
+default-features = false
+
+[dev-dependencies.serde_test]
+version = "1.0"
+
 [features]
 default = ["std"]
 std = ["odds/std", "nodrop/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 #![cfg_attr(not(feature="std"), no_std)]
 extern crate odds;
 extern crate nodrop;
+#[cfg(feature="serde")]
+extern crate serde;
 
 #[cfg(feature = "use_generic_array")]
 extern crate generic_array;
@@ -53,6 +55,9 @@ use std::error::Error;
 use std::any::Any; // core but unused
 
 use nodrop::NoDrop;
+
+#[cfg(feature="serde")]
+use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 mod array;
 mod array_string;
@@ -827,6 +832,51 @@ impl<A: Array<Item=u8>> io::Write for ArrayVec<A> {
         }
     }
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+#[cfg(feature="serde")]
+impl<T: Serialize, A: Array<Item=T>> Serialize for ArrayVec<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.collect_seq(self)
+    }
+}
+
+#[cfg(feature="serde")]
+impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Deserialize<'de> for ArrayVec<A> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        use serde::de::{Visitor, SeqAccess, Error};
+        use std::marker::PhantomData;
+
+        struct ArrayVecVisitor<'de, T: Deserialize<'de>, A: Array<Item=T>>(PhantomData<(&'de (), T, A)>);
+
+        impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Visitor<'de> for ArrayVecVisitor<'de, T, A> {
+            type Value = ArrayVec<A>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an array with no more than {} elements", A::capacity())
+            }
+
+            fn visit_seq<SA>(self, mut seq: SA) -> Result<Self::Value, SA::Error>
+                where SA: SeqAccess<'de>,
+            {
+                let mut values = ArrayVec::<A>::new();
+
+                while let Some(value) = try!(seq.next_element()) {
+                    if let Some(_) = values.push(value) {
+                        return Err(SA::Error::invalid_length(A::capacity() + 1, &self));
+                    }
+                }
+
+                Ok(values)
+            }
+        }
+
+        deserializer.deserialize_seq(ArrayVecVisitor::<T, A>(PhantomData))
+    }
 }
 
 /// Error value indicating insufficient capacity

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "serde")]
+extern crate arrayvec;
+extern crate serde_test;
+
+mod array_vec {
+    use arrayvec::ArrayVec;
+
+    use serde_test::{Token, assert_tokens};
+
+    #[test]
+    fn test_ser_de_empty() {
+        let vec = ArrayVec::<[u32; 0]>::new();
+
+        assert_tokens(&vec, &[
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+        ]);
+    }
+
+
+    #[test]
+    fn test_ser_de() {
+        let mut vec = ArrayVec::<[u32; 3]>::new();
+        vec.push(20);
+        vec.push(55);
+        vec.push(123);
+
+        assert_tokens(&vec, &[
+            Token::Seq { len: Some(3) },
+            Token::U32(20),
+            Token::U32(55),
+            Token::U32(123),
+            Token::SeqEnd,
+        ]);
+    }
+}
+
+mod array_string {
+    use arrayvec::ArrayString;
+
+    use serde_test::{Token, assert_tokens};
+
+    #[test]
+    fn test_ser_de_empty() {
+        let string = ArrayString::<[u8; 0]>::new();
+
+        assert_tokens(&string, &[
+            Token::Str(""),
+        ]);
+    }
+
+
+    #[test]
+    fn test_ser_de() {
+        let string = ArrayString::<[u8; 9]>::from("1234 abcd")
+            .expect("expected exact specified capacity to be enough");
+
+        assert_tokens(&string, &[
+            Token::Str("1234 abcd"),
+        ]);
+    }
+}


### PR DESCRIPTION
This implements serde support under the optional 'serde' feature, and adds unit tests to test said support.

Serde will be optionally included for runtime, but is unfortunately required for running tests - as cargo does not have support for optional dev-dependencies. FEATURES="serde" is added to the travis config, as serde-support tests will not run without it.

See #55 for master PR.

Fixes #54.