### PR TITLE
Add serde support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,16 @@ version = "0.1.8"
 path = "nodrop"
 default-features = false
 
+[dependencies.serde]
+version = "1.0"
+default-features = false
+optional = true
+
 [features]
-default = ["std"]
-std = ["odds/std", "nodrop/std"]
+default = ["std", "use_serde"]
+std = ["odds/std", "nodrop/std", "serde/std"]
 use_union = ["nodrop/use_union"]
+use_serde = ["serde"]
+
+[dev-dependencies]
+serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 //!   - Use the unstable feature untagged unions for the internal implementation,
 //!     which has reduced space overhead
 //!
+//! - `use_serde`
+//! - Optional
+//! - Support Serde serialization and deserialization.
 #![doc(html_root_url="https://docs.rs/arrayvec/0.3/")]
 #![cfg_attr(not(feature="std"), no_std)]
 extern crate odds;
@@ -21,6 +24,9 @@ extern crate nodrop;
 
 #[cfg(not(feature="std"))]
 extern crate core as std;
+
+#[cfg(feature="use_serde")]
+extern crate serde;
 
 use std::cmp;
 use std::iter;
@@ -866,3 +872,8 @@ impl<T> fmt::Debug for CapacityError<T> {
         write!(f, "{}: {}", "CapacityError", CAPERROR)
     }
 }
+
+#[cfg(feature="use_serde")]
+mod serde_impls;
+#[cfg(feature="use_serde")]
+pub use serde_impls::*;

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,0 +1,77 @@
+use std::marker::PhantomData;
+use std::fmt;
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::{SerializeSeq};
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
+use {ArrayVec, ArrayString};
+use array::Array;
+
+impl<A: Array> Serialize for ArrayVec<A>
+    where A::Item: Serialize
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = try!(serializer.serialize_seq(Some(self.len())));
+        for i in self.iter() {
+            try!(seq.serialize_element(i));
+        }
+        seq.end()
+    }
+}
+
+struct ArrayVecVisitor<'de, A: 'de>(PhantomData<&'de A>);
+
+impl<'de, A: Array> Visitor<'de> for ArrayVecVisitor<'de, A>
+    where A::Item: Deserialize<'de>
+{
+    type Value = ArrayVec<A>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("A sequence.")
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        use serde::de::Error;
+        let mut ret = ArrayVec::<A>::new();
+        while let Some(elem) = try!(seq.next_element()) {
+            if ret.push(elem).is_some() {
+                return Err(S::Error::custom("Too many elements"));
+            }
+        }
+        Ok(ret)
+    }
+}
+
+impl<'de, A: 'de+Array> Deserialize<'de> for ArrayVec<A> 
+    where A::Item: Deserialize<'de>
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(ArrayVecVisitor::<A>(PhantomData))
+    }
+}
+
+
+impl<A: Array<Item=u8>> Serialize for ArrayString<A> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self)
+    }
+}
+
+struct ArrayStringVisitor<'de, A: 'de>(PhantomData<&'de A>);
+
+impl<'de, A: Array<Item=u8>> Visitor<'de> for ArrayStringVisitor<'de, A>{
+    type Value = ArrayString<A>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("A string")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        ArrayString::from(v).map_err(|_| E::custom("String too large"))
+    }
+}
+
+impl<'de, A: Array<Item=u8>+'de> Deserialize<'de> for ArrayString<A> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(ArrayStringVisitor(PhantomData))
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,7 @@
 extern crate arrayvec;
+extern crate serde;
+extern crate serde_test;
+
 
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
@@ -434,4 +437,76 @@ fn test_drop_in_insert() {
         assert_eq!(flag.get(), 1);
     }
     assert_eq!(flag.get(), 3);
+}
+
+#[test]
+fn test_serde_arrayvec_empty() {
+    use serde_test::{Token, assert_tokens};
+    let v = ArrayVec::<[u64; 5]>::new();
+    assert_tokens(&v, &[
+        Token::Seq { len: Some(0) },
+        Token::SeqEnd,
+    ]);
+}
+
+#[test]
+fn test_serde_arrayvec() {
+    use serde_test::{Token, assert_tokens};
+    let mut v = ArrayVec::<[u64; 5]>::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+    assert_tokens(&v, &[
+        Token::Seq { len: Some(5) },
+        Token::U64(1),
+        Token::U64(2),
+        Token::U64(3),
+        Token::U64(4),
+        Token::U64(5),
+        Token::SeqEnd,
+    ]);
+}
+
+#[test]
+fn test_serde_arrayvec_fail() {
+    use serde_test::{Token, assert_de_tokens_error};
+        assert_de_tokens_error::<ArrayVec<[u64; 4]>>(&[
+        Token::Seq { len: Some(5) },
+        Token::U64(1),
+        Token::U64(2),
+        Token::U64(3),
+        Token::U64(4),
+        Token::U64(5),
+        Token::SeqEnd,
+    ], "Too many elements");
+}
+
+#[test]
+fn test_serde_arraystring_empty() {
+    use serde_test::{Token, assert_tokens};
+    let s = "";
+    let v = ArrayString::<[u8; 16]>::from(s).unwrap();
+    assert_tokens(&v, &[
+        Token::Str(s),
+    ]);
+}
+
+#[test]
+fn test_serde_arraystring() {
+    use serde_test::{Token, assert_tokens};
+    let s = "hello";
+    let v = ArrayString::<[u8; 16]>::from(s).unwrap();
+    assert_tokens(&v, &[
+        Token::Str(s),
+    ]);
+}
+
+#[test]
+fn test_serde_arraystring_fail() {
+    use serde_test::{Token, assert_de_tokens_error};
+    assert_de_tokens_error::<ArrayString<[u8; 3]>>(&[
+        Token::Str("hello world"),
+    ], "String too large");
 }


### PR DESCRIPTION
Add support for serde to both ArrayVec and ArrayString.

I think I did this right.  The 6 tests I added all pass.  The downside is that we have to make serde  a default feature in order to get tests working, in so far as everyone on #rust-offtopic knew.  This isn't a major problem since Serde doesn't force us to use std.

My motivating use case is an implementation of a disk-backed B+ tree.  This also makes it possible to use Arrayvec  to avoid allocations with networking applications when using Serde to encode and decode packets.

There might be formatting problems.  If there are, let me know and I'll fix them.