### PR TITLE
Prepare 0.4, more vec-like api and error reform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - FEATURES='serde-1'
 matrix:
   include:
-    - rust: 1.18.0
+    - rust: 1.15.0
     - rust: stable
       env:
         - NODEFAULT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - FEATURES='serde-1'
 matrix:
   include:
-    - rust: 1.12.0
+    - rust: 1.18.0
     - rust: stable
       env:
         - NODEFAULT=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ default-features = false
 [dev-dependencies.serde_test]
 version = "1.0"
 
+[dev-dependencies]
+matches = { version = "0.1" }
+
 [features]
 default = ["std"]
 std = ["odds/std", "nodrop/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ default = ["std"]
 std = ["odds/std", "nodrop/std"]
 use_union = ["nodrop/use_union"]
 serde-1 = ["serde"]
+
+[package.metadata.docs.rs]
+features = ["serde-1"]

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 arrayvec
 ========
 
-A vector with fixed capacity.  Requires Rust 1.12.0 or later.
+A vector with fixed capacity.
 
 Please read the `API documentation here`__
 

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -12,6 +12,7 @@ use std::slice;
 use array::{Array, ArrayExt};
 use array::Index;
 use CapacityError;
+use errors::PubCrateNew;
 use odds::char::encode_utf8;
 
 #[cfg(feature="serde-1")]

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -68,7 +68,7 @@ impl<A: Array<Item=u8>> ArrayString<A> {
     /// ```
     pub fn from(s: &str) -> Result<Self, CapacityError<&str>> {
         let mut arraystr = Self::new();
-        try!(arraystr.push_str(s));
+        arraystr.try_push_str(s)?;
         Ok(arraystr)
     }
 
@@ -84,7 +84,7 @@ impl<A: Array<Item=u8>> ArrayString<A> {
     pub fn from_byte_string(b: &A) -> Result<Self, Utf8Error> {
         let mut arraystr = Self::new();
         let s = try!(str::from_utf8(b.as_slice()));
-        let _result = arraystr.push_str(s);
+        let _result = arraystr.try_push_str(s);
         debug_assert!(_result.is_ok());
         Ok(arraystr)
     }
@@ -123,14 +123,34 @@ impl<A: Array<Item=u8>> ArrayString<A> {
     ///
     /// let mut string = ArrayString::<[_; 2]>::new();
     ///
-    /// string.push('a').unwrap();
-    /// string.push('b').unwrap();
-    /// let overflow = string.push('c');
+    /// string.push('a');
+    /// string.push('b');
+    ///
+    /// assert_eq!(&string[..], "ab");
+    /// ```
+    pub fn push(&mut self, c: char) {
+        self.try_push(c).unwrap();
+    }
+
+    /// Adds the given char to the end of the string.
+    ///
+    /// Returns `Ok` if the push succeeds.
+    ///
+    /// **Errors** if the backing array is not large enough to fit the additional char.
+    ///
+    /// ```
+    /// use arrayvec::ArrayString;
+    ///
+    /// let mut string = ArrayString::<[_; 2]>::new();
+    ///
+    /// string.try_push('a').unwrap();
+    /// string.try_push('b').unwrap();
+    /// let overflow = string.try_push('c');
     ///
     /// assert_eq!(&string[..], "ab");
     /// assert_eq!(overflow.unwrap_err().element(), 'c');
     /// ```
-    pub fn push(&mut self, c: char) -> Result<(), CapacityError<char>> {
+    pub fn try_push(&mut self, c: char) -> Result<(), CapacityError<char>> {
         let len = self.len();
         unsafe {
             match encode_utf8(c, &mut self.raw_mut_bytes()[len..]) {
@@ -154,16 +174,36 @@ impl<A: Array<Item=u8>> ArrayString<A> {
     ///
     /// let mut string = ArrayString::<[_; 2]>::new();
     ///
-    /// string.push_str("a").unwrap();
-    /// let overflow1 = string.push_str("bc");
-    /// string.push_str("d").unwrap();
-    /// let overflow2 = string.push_str("ef");
+    /// string.push_str("a");
+    /// string.push_str("d");
+    ///
+    /// assert_eq!(&string[..], "ad");
+    /// ```
+    pub fn push_str(&mut self, s: &str) {
+        self.try_push_str(s).unwrap()
+    }
+
+    /// Adds the given string slice to the end of the string.
+    ///
+    /// Returns `Ok` if the push succeeds.
+    ///
+    /// **Errors** if the backing array is not large enough to fit the string.
+    ///
+    /// ```
+    /// use arrayvec::ArrayString;
+    ///
+    /// let mut string = ArrayString::<[_; 2]>::new();
+    ///
+    /// string.try_push_str("a").unwrap();
+    /// let overflow1 = string.try_push_str("bc");
+    /// string.try_push_str("d").unwrap();
+    /// let overflow2 = string.try_push_str("ef");
     ///
     /// assert_eq!(&string[..], "ad");
     /// assert_eq!(overflow1.unwrap_err().element(), "bc");
     /// assert_eq!(overflow2.unwrap_err().element(), "ef");
     /// ```
-    pub fn push_str<'a>(&mut self, s: &'a str) -> Result<(), CapacityError<&'a str>> {
+    pub fn try_push_str<'a>(&mut self, s: &'a str) -> Result<(), CapacityError<&'a str>> {
         if s.len() > self.capacity() - self.len() {
             return Err(CapacityError::new(s));
         }
@@ -274,10 +314,11 @@ impl<A: Array<Item=u8>> fmt::Display for ArrayString<A> {
 /// `Write` appends written data to the end of the string.
 impl<A: Array<Item=u8>> fmt::Write for ArrayString<A> {
     fn write_char(&mut self, c: char) -> fmt::Result {
-        self.push(c).map_err(|_| fmt::Error)
+        self.try_push(c).map_err(|_| fmt::Error)
     }
+
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.push_str(s).map_err(|_| fmt::Error)
+        self.try_push_str(s).map_err(|_| fmt::Error)
     }
 }
 
@@ -288,7 +329,7 @@ impl<A: Array<Item=u8> + Copy> Clone for ArrayString<A> {
     fn clone_from(&mut self, rhs: &Self) {
         // guaranteed to fit due to types matching.
         self.clear();
-        self.push_str(rhs).ok();
+        self.try_push_str(rhs).ok();
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,15 +51,15 @@ impl<T> fmt::Debug for CapacityError<T> {
 }
 
 pub enum InsertError<T> {
-    Full(T),
-    OutOfBounds,
+    Capacity(CapacityError<T>),
+    OutOfBounds(OutOfBoundsError),
 }
 
 impl<T> InsertError<T> {
     fn description(&self) -> &'static str {
         match *self {
-            InsertError::Full(_) => "ArrayVec is already at full capacity",
-            InsertError::OutOfBounds => "index is out of bounds",
+            InsertError::Capacity(_) => "ArrayVec is already at full capacity",
+            InsertError::OutOfBounds(_) => "index is out of bounds",
         }
     }
 }
@@ -69,6 +69,12 @@ impl<T> InsertError<T> {
 impl<T: Any> Error for InsertError<T> {
     fn description(&self) -> &str {
         self.description()
+    }
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            InsertError::Capacity(ref e) => Some(e as &Error),
+            InsertError::OutOfBounds(ref e) => Some(e as &Error),
+        }
     }
 }
 
@@ -81,20 +87,20 @@ impl<T> fmt::Display for InsertError<T> {
 impl<T> fmt::Debug for InsertError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            InsertError::Full(_) => write!(f, "InsertError::Full: ")?,
-            InsertError::OutOfBounds => write!(f, "InsertError::OutOfBounds: ")?,
+            InsertError::Capacity(_) => write!(f, "InsertError::Capacity: ")?,
+            InsertError::OutOfBounds(_) => write!(f, "InsertError::OutOfBounds: ")?,
         }
         write!(f, "{}", self.description())
     }
 }
 
-pub struct RemoveError {
+pub struct OutOfBoundsError {
     _priv: ()
 }
 
-impl RemoveError {
+impl OutOfBoundsError {
     pub(crate) fn new() -> Self {
-        RemoveError { _priv: () }
+        OutOfBoundsError { _priv: () }
     }
 
     fn description(&self) -> &'static str {
@@ -104,20 +110,20 @@ impl RemoveError {
 
 #[cfg(feature="std")]
 /// Requires `features="std"`.
-impl Error for RemoveError {
+impl Error for OutOfBoundsError {
     fn description(&self) -> &str {
         self.description()
     }
 }
 
-impl fmt::Display for RemoveError {
+impl fmt::Display for OutOfBoundsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
 
-impl fmt::Debug for RemoveError {
+impl fmt::Debug for OutOfBoundsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RemoveError: {}", self.description())
+        write!(f, "OutOfBoundsError: {}", self.description())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,13 +10,19 @@ pub struct CapacityError<T = ()> {
     element: T,
 }
 
-impl<T> CapacityError<T> {
-    pub(crate) fn new(element: T) -> CapacityError<T> {
+pub trait PubCrateNew<T> {
+    fn new(elt: T) -> Self;
+}
+
+impl<T> PubCrateNew<T> for CapacityError<T> {
+    fn new(element: T) -> CapacityError<T> {
         CapacityError {
             element: element,
         }
     }
+}
 
+impl<T> CapacityError<T> {
     /// Extract the overflowing element
     pub fn element(self) -> T {
         self.element
@@ -50,59 +56,18 @@ impl<T> fmt::Debug for CapacityError<T> {
     }
 }
 
-pub enum InsertError<T> {
-    Capacity(CapacityError<T>),
-    OutOfBounds(OutOfBoundsError),
-}
-
-impl<T> InsertError<T> {
-    fn description(&self) -> &'static str {
-        match *self {
-            InsertError::Capacity(_) => "ArrayVec is already at full capacity",
-            InsertError::OutOfBounds(_) => "index is out of bounds",
-        }
-    }
-}
-
-#[cfg(feature="std")]
-/// Requires `features="std"`.
-impl<T: Any> Error for InsertError<T> {
-    fn description(&self) -> &str {
-        self.description()
-    }
-    fn cause(&self) -> Option<&Error> {
-        match *self {
-            InsertError::Capacity(ref e) => Some(e as &Error),
-            InsertError::OutOfBounds(ref e) => Some(e as &Error),
-        }
-    }
-}
-
-impl<T> fmt::Display for InsertError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl<T> fmt::Debug for InsertError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            InsertError::Capacity(_) => write!(f, "InsertError::Capacity: ")?,
-            InsertError::OutOfBounds(_) => write!(f, "InsertError::OutOfBounds: ")?,
-        }
-        write!(f, "{}", self.description())
-    }
-}
-
 pub struct OutOfBoundsError {
     _priv: ()
 }
 
-impl OutOfBoundsError {
-    pub(crate) fn new() -> Self {
+impl PubCrateNew<()> for OutOfBoundsError {
+    fn new(_: ()) -> Self {
         OutOfBoundsError { _priv: () }
     }
+}
 
+
+impl OutOfBoundsError {
     fn description(&self) -> &'static str {
         "remove index is out of bounds"
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,39 +56,3 @@ impl<T> fmt::Debug for CapacityError<T> {
     }
 }
 
-pub struct OutOfBoundsError {
-    _priv: ()
-}
-
-impl PubCrateNew<()> for OutOfBoundsError {
-    fn new(_: ()) -> Self {
-        OutOfBoundsError { _priv: () }
-    }
-}
-
-
-impl OutOfBoundsError {
-    fn description(&self) -> &'static str {
-        "remove index is out of bounds"
-    }
-}
-
-#[cfg(feature="std")]
-/// Requires `features="std"`.
-impl Error for OutOfBoundsError {
-    fn description(&self) -> &str {
-        self.description()
-    }
-}
-
-impl fmt::Display for OutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl fmt::Debug for OutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "OutOfBoundsError: {}", self.description())
-    }
-}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,123 @@
+use std::fmt;
+#[cfg(feature="std")]
+use std::any::Any;
+#[cfg(feature="std")]
+use std::error::Error;
+
+/// Error value indicating insufficient capacity
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CapacityError<T = ()> {
+    element: T,
+}
+
+impl<T> CapacityError<T> {
+    pub(crate) fn new(element: T) -> CapacityError<T> {
+        CapacityError {
+            element: element,
+        }
+    }
+
+    /// Extract the overflowing element
+    pub fn element(self) -> T {
+        self.element
+    }
+
+    /// Convert into a `CapacityError` that does not carry an element.
+    pub fn simplify(self) -> CapacityError {
+        CapacityError { element: () }
+    }
+}
+
+const CAPERROR: &'static str = "insufficient capacity";
+
+#[cfg(feature="std")]
+/// Requires `features="std"`.
+impl<T: Any> Error for CapacityError<T> {
+    fn description(&self) -> &str {
+        CAPERROR
+    }
+}
+
+impl<T> fmt::Display for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", CAPERROR)
+    }
+}
+
+impl<T> fmt::Debug for CapacityError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", "CapacityError", CAPERROR)
+    }
+}
+
+pub enum InsertError<T> {
+    Full(T),
+    OutOfBounds,
+}
+
+impl<T> InsertError<T> {
+    fn description(&self) -> &'static str {
+        match *self {
+            InsertError::Full(_) => "ArrayVec is already at full capacity",
+            InsertError::OutOfBounds => "index is out of bounds",
+        }
+    }
+}
+
+#[cfg(feature="std")]
+/// Requires `features="std"`.
+impl<T: Any> Error for InsertError<T> {
+    fn description(&self) -> &str {
+        self.description()
+    }
+}
+
+impl<T> fmt::Display for InsertError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl<T> fmt::Debug for InsertError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InsertError::Full(_) => write!(f, "InsertError::Full: ")?,
+            InsertError::OutOfBounds => write!(f, "InsertError::OutOfBounds: ")?,
+        }
+        write!(f, "{}", self.description())
+    }
+}
+
+pub struct RemoveError {
+    _priv: ()
+}
+
+impl RemoveError {
+    pub(crate) fn new() -> Self {
+        RemoveError { _priv: () }
+    }
+
+    fn description(&self) -> &'static str {
+        "remove index is out of bounds"
+    }
+}
+
+#[cfg(feature="std")]
+/// Requires `features="std"`.
+impl Error for RemoveError {
+    fn description(&self) -> &str {
+        self.description()
+    }
+}
+
+impl fmt::Display for RemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl fmt::Debug for RemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RemoveError: {}", self.description())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@
 //!   - Use the unstable feature untagged unions for the internal implementation,
 //!     which has reduced space overhead
 //!
-//! **arrayvec Requires Rust 1.18**
+//! ## Rust Version
+//!
+//! This version of arrayvec requires Rust 1.15 or later.
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.3/")]
 #![cfg_attr(not(feature="std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(&array[..], &[2, 3]);
     /// ```
     pub fn remove(&mut self, index: usize) -> A::Item {
-        self.remove_opt(index)
+        self.pop_at(index)
             .unwrap_or_else(|| {
                 panic_oob!("remove", index, self.len())
             })
@@ -411,22 +411,21 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and shift down the following elements.
     ///
-    /// This is a checked version of `.remove(index)`. Returns `None` if the
-    /// index is greater or equal to the length of the vector. Otherwise, return
-    /// the element inside `Some`.
+    /// This is a checked version of `.remove(index)`. Returns `None` if there
+    /// is no element at `index`. Otherwise, return the element inside `Some`.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
     ///
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
-    /// assert!(array.remove_opt(0).is_some());
+    /// assert!(array.pop_at(0).is_some());
     /// assert_eq!(&array[..], &[2, 3]);
     ///
-    /// assert!(array.remove_opt(2).is_none());
-    /// assert!(array.remove_opt(10).is_none());
+    /// assert!(array.pop_at(2).is_none());
+    /// assert!(array.pop_at(10).is_none());
     /// ```
-    pub fn remove_opt(&mut self, index: usize) -> Option<A::Item> {
+    pub fn pop_at(&mut self, index: usize) -> Option<A::Item> {
         if index >= self.len() {
             None
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,25 +329,48 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// This operation is O(1).
     ///
-    /// Return `Some(` *element* `)` if the index is in bounds, else `None`.
+    /// Return *element* if the index is in bound, else panic.
+    ///
+    /// ***Panics*** if the `index` is out of bounds.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
     ///
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
-    /// assert_eq!(array.swap_remove(0), Some(1));
+    /// assert_eq!(array.swap_remove(0), 1);
     /// assert_eq!(&array[..], &[3, 2]);
     ///
-    /// assert_eq!(array.swap_remove(10), None);
+    /// assert_eq!(array.swap_remove(1), 2);
+    /// assert_eq!(&array[..], &[3]);
     /// ```
-    pub fn swap_remove(&mut self, index: usize) -> Option<A::Item> {
+    pub fn swap_remove(&mut self, index: usize) -> A::Item {
+        self.try_swap_remove(index).unwrap()
+    }
+
+    /// Remove the element at `index` and swap the last element into its place.
+    ///
+    /// This operation is O(1).
+    ///
+    /// Return `Ok(` *element* `)` if the index is in bounds, else an error.
+    ///
+    /// ```
+    /// use arrayvec::ArrayVec;
+    ///
+    /// let mut array = ArrayVec::from([1, 2, 3]);
+    ///
+    /// assert!(array.try_swap_remove(0).is_ok());
+    /// assert_eq!(&array[..], &[3, 2]);
+    ///
+    /// assert!(array.try_swap_remove(10).is_err());
+    /// ```
+    pub fn try_swap_remove(&mut self, index: usize) -> Result<A::Item, RemoveError> {
         let len = self.len();
         if index >= len {
-            return None
+            return Err(RemoveError::new())
         }
         self.swap(index, len - 1);
-        self.pop()
+        self.pop().ok_or_else(|| panic!())
     }
 
     /// Remove the element at `index` and shift down the following elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,6 @@ impl<A: Array> ArrayVec<A> {
     /// The `index` must be strictly less than the length of the vector.
     ///
     /// ***Panics*** if the `index` is out of bounds.
-    /// vector.
     ///
     /// ```
     /// use arrayvec::ArrayVec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -977,7 +977,7 @@ impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Deserialize<'de> for ArrayVec<A
                 let mut values = ArrayVec::<A>::new();
 
                 while let Some(value) = try!(seq.next_element()) {
-                    if let Some(_) = values.push(value) {
+                    if let Err(_) = values.try_push(value) {
                         return Err(SA::Error::invalid_length(A::capacity() + 1, &self));
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,10 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 mod array;
 mod array_string;
+mod range;
 
 pub use array::Array;
-pub use odds::IndexRange as RangeArgument;
+pub use range::RangeArgument;
 use array::Index;
 pub use array_string::ArrayString;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //!
 //! - `std`
 //!   - Optional, enabled by default
-//!   - Requires Rust 1.6 *to disable*
 //!   - Use libstd
 //!
 //! - `use_union`
@@ -13,6 +12,8 @@
 //!   - Requires Rust nightly channel
 //!   - Use the unstable feature untagged unions for the internal implementation,
 //!     which has reduced space overhead
+//!
+//! **arrayvec Requires Rust 1.18**
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.3/")]
 #![cfg_attr(not(feature="std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,10 +277,10 @@ impl<A: Array> ArrayVec<A> {
     /// ```
     pub fn try_insert(&mut self, index: usize, element: A::Item) -> Result<(), InsertError<A::Item>> {
         if self.len() == self.capacity() {
-            return Err(InsertError::Full(element));
+            return Err(InsertError::Capacity(CapacityError::new(element)));
         }
         if index > self.len() {
-            return Err(InsertError::OutOfBounds);
+            return Err(InsertError::OutOfBounds(OutOfBoundsError::new()));
         }
         let len = self.len();
 
@@ -365,10 +365,10 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// assert!(array.try_swap_remove(10).is_err());
     /// ```
-    pub fn try_swap_remove(&mut self, index: usize) -> Result<A::Item, RemoveError> {
+    pub fn try_swap_remove(&mut self, index: usize) -> Result<A::Item, OutOfBoundsError> {
         let len = self.len();
         if index >= len {
-            return Err(RemoveError::new())
+            return Err(OutOfBoundsError::new())
         }
         self.swap(index, len - 1);
         self.pop().ok_or_else(|| panic!())
@@ -411,9 +411,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert!(array.try_remove(2).is_err());
     /// assert!(array.try_remove(10).is_err());
     /// ```
-    pub fn try_remove(&mut self, index: usize) -> Result<A::Item, RemoveError> {
+    pub fn try_remove(&mut self, index: usize) -> Result<A::Item, OutOfBoundsError> {
         if index >= self.len() {
-            Err(RemoveError::new())
+            Err(OutOfBoundsError::new())
         } else {
             self.drain(index..index + 1).next().ok_or_else(|| panic!())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,14 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 mod array;
 mod array_string;
 mod range;
-pub mod errors;
+mod errors;
 
 pub use array::Array;
 pub use range::RangeArgument;
 use array::Index;
 pub use array_string::ArrayString;
-use errors::*;
+use errors::PubCrateNew;
+pub use errors::CapacityError;
 
 
 unsafe fn new_array<A: Array>() -> A {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl<A: Array> ArrayVec<A> {
 
     /// Push `element` to the end of the vector.
     ///
-    /// ***Panics*** if the array is already full.
+    /// ***Panics*** if the vector is already full.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -180,8 +180,8 @@ impl<A: Array> ArrayVec<A> {
 
     /// Push `element` to the end of the vector.
     ///
-    /// Return `Ok` if the push succeeds, or and return an error if the vector
-    /// is full.
+    /// Return `Ok` if the push succeeds, or return an error if the vector
+    /// is already full.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -194,9 +194,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert!(push1.is_ok());
     /// assert!(push2.is_ok());
     ///
-    /// let overflow = array.try_push(3);
-    ///
     /// assert_eq!(&array[..], &[1, 2]);
+    ///
+    /// let overflow = array.try_push(3);
     ///
     /// assert!(overflow.is_err());
     /// ```
@@ -217,7 +217,7 @@ impl<A: Array> ArrayVec<A> {
     /// It is up to the caller to ensure the capacity of the vector is
     /// sufficiently large.
     ///
-    /// May use debug assertions to check that the arrayvec is not full.
+    /// This method *may* use debug assertions to check that the arrayvec is not full.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -241,7 +241,7 @@ impl<A: Array> ArrayVec<A> {
         self.set_len(len + 1);
     }
 
-    /// Insert `element` in position `index`.
+    /// Insert `element` at position `index`.
     ///
     /// Shift up all elements after `index`.
     ///
@@ -264,14 +264,12 @@ impl<A: Array> ArrayVec<A> {
         self.try_insert(index, element).unwrap()
     }
 
-    /// Insert `element` in position `index`.
+    /// Insert `element` at position `index`.
     ///
     /// Shift up all elements after `index`; the `index` must be less than
     /// or equal to the length.
     ///
-    /// Returns an error if:
-    ///
-    /// - The vector is at full capacity
+    /// Returns an error if vector is already at full capacity.
     ///
     /// ***Panics*** `index` is out of bounds.
     ///
@@ -312,7 +310,7 @@ impl<A: Array> ArrayVec<A> {
         Ok(())
     }
 
-    /// Remove the last element in the vector.
+    /// Remove the last element in the vector and return it.
     ///
     /// Return `Some(` *element* `)` if the vector is non-empty, else `None`.
     ///
@@ -341,7 +339,7 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// This operation is O(1).
     ///
-    /// Return *element* if the index is in bound, else panic.
+    /// Return the *element* if the index is in bounds, else panic.
     ///
     /// ***Panics*** if the `index` is out of bounds.
     ///
@@ -365,7 +363,8 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and swap the last element into its place.
     ///
-    /// Checked version of `.swap_remove`. This operation is O(1).
+    /// This is a checked version of `.swap_remove`.  
+    /// This operation is O(1).
     ///
     /// Return `Some(` *element* `)` if the index is in bounds, else `None`.
     ///
@@ -390,7 +389,9 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and shift down the following elements.
     ///
-    /// ***Panics*** if the `index` is greater or equal to the length of the
+    /// The `index` must be strictly less than the length of the vector.
+    ///
+    /// ***Panics*** if the `index` is out of bounds.
     /// vector.
     ///
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,7 @@ impl<A: Array> ArrayVec<A> {
     /// use arrayvec::ArrayVec;
     ///
     /// let mut v = ArrayVec::from([1, 2, 3]);
-    /// let u: Vec<_> = v.drain(0..2).collect();
+    /// let u: ArrayVec<[_; 3]> = v.drain(0..2).collect();
     /// assert_eq!(&v[..], &[3]);
     /// assert_eq!(&u[..], &[1, 2]);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,8 @@ impl<A: Array> ArrayVec<A> {
 
     /// Push `element` to the end of the vector.
     ///
-    /// Return `None` if the push succeeds, or and return `Some(` *element* `)`
-    /// if the vector is full.
+    /// Return `Ok` if the push succeeds, or and return an error if the vector
+    /// is full.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -207,7 +207,7 @@ impl<A: Array> ArrayVec<A> {
     /// It is up to the caller to ensure the capacity of the vector is
     /// sufficiently large.
     ///
-    /// # Examples
+    /// May use debug assertions to check that the arrayvec is not full.
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -460,7 +460,8 @@ impl<A: Array> ArrayVec<A> {
 
     /// Set the vector's length without dropping or moving out elements
     ///
-    /// May panic if `length` is greater than the capacity.
+    /// May use debug assertions to check that `length` is not greater than the
+    /// capacity.
     ///
     /// This function is `unsafe` because it changes the notion of the
     /// number of “valid” elements in the vector. Use with care.

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,0 +1,42 @@
+
+use std::ops::{
+    RangeFull,
+    RangeFrom,
+    RangeTo,
+    Range,
+};
+
+/// `RangeArgument` is implemented by Rust's built-in range types, produced
+/// by range syntax like `..`, `a..`, `..b` or `c..d`.
+///
+/// Note: This is arrayvec's provisional trait, waiting for stable Rust to
+/// provide an equivalent.
+pub trait RangeArgument {
+    #[inline]
+    /// Start index (inclusive)
+    fn start(&self) -> Option<usize> { None }
+    #[inline]
+    /// End index (exclusive)
+    fn end(&self) -> Option<usize> { None }
+}
+
+
+impl RangeArgument for RangeFull {}
+
+impl RangeArgument for RangeFrom<usize> {
+    #[inline]
+    fn start(&self) -> Option<usize> { Some(self.start) }
+}
+
+impl RangeArgument for RangeTo<usize> {
+    #[inline]
+    fn end(&self) -> Option<usize> { Some(self.end) }
+}
+
+impl RangeArgument for Range<usize> {
+    #[inline]
+    fn start(&self) -> Option<usize> { Some(self.start) }
+    #[inline]
+    fn end(&self) -> Option<usize> { Some(self.end) }
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -434,3 +434,19 @@ fn test_drop_in_insert() {
     }
     assert_eq!(flag.get(), 3);
 }
+
+#[test]
+fn test_pop_at() {
+    let mut v = ArrayVec::<[String; 4]>::new();
+    let s = String::from;
+    v.push(s("a"));
+    v.push(s("b"));
+    v.push(s("c"));
+    v.push(s("d"));
+
+    assert_eq!(v.pop_at(4), None);
+    assert_eq!(v.pop_at(1), Some(s("b")));
+    assert_eq!(v.pop_at(1), Some(s("c")));
+    assert_eq!(v.pop_at(2), None);
+    assert_eq!(&v[..], &["a", "d"]);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -307,7 +307,7 @@ fn test_string() {
 
     let text = "hello world";
     let mut s = ArrayString::<[_; 16]>::new();
-    s.push_str(text).unwrap();
+    s.try_push_str(text).unwrap();
     assert_eq!(&s, text);
     assert_eq!(text, &s);
 
@@ -317,10 +317,10 @@ fn test_string() {
     assert_eq!(map[text], 1);
 
     let mut t = ArrayString::<[_; 2]>::new();
-    assert!(t.push_str(text).is_err());
+    assert!(t.try_push_str(text).is_err());
     assert_eq!(&t, "");
 
-    t.push_str("ab").unwrap();
+    t.push_str("ab");
     // DerefMut
     let tmut: &mut str = &mut t;
     assert_eq!(tmut, "ab");
@@ -328,7 +328,7 @@ fn test_string() {
     // Test Error trait / try
     let t = || -> Result<(), Box<Error>> {
         let mut t = ArrayString::<[_; 2]>::new();
-        try!(t.push_str(text));
+        try!(t.try_push_str(text));
         Ok(())
     }();
     assert!(t.is_err());
@@ -355,7 +355,7 @@ fn test_string_from_bytes() {
 fn test_string_clone() {
     let text = "hi";
     let mut s = ArrayString::<[_; 4]>::new();
-    s.push_str("abcd").unwrap();
+    s.push_str("abcd");
     let t = ArrayString::<[_; 4]>::from(text).unwrap();
     s.clone_from(&t);
     assert_eq!(&t, &s);
@@ -366,14 +366,14 @@ fn test_string_push() {
     let text = "abcαβγ";
     let mut s = ArrayString::<[_; 8]>::new();
     for c in text.chars() {
-        if let Err(_) = s.push(c) {
+        if let Err(_) = s.try_push(c) {
             break;
         }
     }
     assert_eq!("abcαβ", &s[..]);
-    s.push('x').ok();
+    s.push('x');
     assert_eq!("abcαβx", &s[..]);
-    assert!(s.push('x').is_err());
+    assert!(s.try_push('x').is_err());
 }
 
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ extern crate arrayvec;
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
 use std::mem;
-use arrayvec::errors::CapacityError;
+use arrayvec::CapacityError;
 
 use std::collections::HashMap;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ extern crate arrayvec;
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
 use std::mem;
-use arrayvec::errors::InsertError;
+use arrayvec::errors::CapacityError;
 
 use std::collections::HashMap;
 
@@ -222,13 +222,12 @@ fn test_drop_panic_into_iter() {
 fn test_insert() {
     let mut v = ArrayVec::from([]);
     assert_matches!(v.try_push(1), Err(_));
-    assert_matches!(v.try_insert(0, 1), Err(_));
 
     let mut v = ArrayVec::<[_; 3]>::new();
     v.insert(0, 0);
     v.insert(1, 1);
-    let ret1 = v.try_insert(3, 3);
-    assert_matches!(ret1, Err(InsertError::OutOfBounds(_)));
+    //let ret1 = v.try_insert(3, 3);
+    //assert_matches!(ret1, Err(InsertError::OutOfBounds(_)));
     assert_eq!(&v[..], &[0, 1]);
     v.insert(2, 2);
     assert_eq!(&v[..], &[0, 1, 2]);
@@ -238,8 +237,9 @@ fn test_insert() {
     assert_matches!(ret2, Err(_));
 
     let mut v = ArrayVec::from([2]);
-    assert_matches!(v.try_insert(1, 1), Err(InsertError::Capacity(_)));
-    assert_matches!(v.try_insert(2, 1), Err(InsertError::Capacity(_)));
+    assert_matches!(v.try_insert(0, 1), Err(CapacityError { .. }));
+    assert_matches!(v.try_insert(1, 1), Err(CapacityError { .. }));
+    //assert_matches!(v.try_insert(2, 1), Err(CapacityError { .. }));
 }
 
 #[test]
@@ -386,13 +386,11 @@ fn test_insert_at_length() {
     assert_eq!(&v[..], &["a", "b"]);
 }
 
+#[should_panic]
 #[test]
 fn test_insert_out_of_bounds() {
     let mut v = ArrayVec::<[_; 8]>::new();
-    let result = v.try_insert(1, "test");
-    assert_matches!(result, Err(_));
-    assert_eq!(v.len(), 0);
-
+    let _ = v.try_insert(1, "test");
 }
 
 /*

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,7 @@ extern crate arrayvec;
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
 use std::mem;
+use arrayvec::errors::InsertError;
 
 use std::collections::HashMap;
 
@@ -226,18 +227,19 @@ fn test_insert() {
     let mut v = ArrayVec::<[_; 3]>::new();
     v.insert(0, 0);
     v.insert(1, 1);
-    v.insert(2, 2);
     let ret1 = v.try_insert(3, 3);
+    assert_matches!(ret1, Err(InsertError::OutOfBounds(_)));
+    assert_eq!(&v[..], &[0, 1]);
+    v.insert(2, 2);
     assert_eq!(&v[..], &[0, 1, 2]);
-    assert_matches!(ret1, Err(_));
 
     let ret2 = v.try_insert(1, 9);
     assert_eq!(&v[..], &[0, 1, 2]);
     assert_matches!(ret2, Err(_));
 
     let mut v = ArrayVec::from([2]);
-    assert_matches!(v.try_insert(1, 1), Err(_));
-    assert_matches!(v.try_insert(2, 1), Err(_));
+    assert_matches!(v.try_insert(1, 1), Err(InsertError::Capacity(_)));
+    assert_matches!(v.try_insert(2, 1), Err(InsertError::Capacity(_)));
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -31,9 +31,9 @@ fn test_u16_index() {
     const N: usize = 4096;
     let mut vec: ArrayVec<[_; N]> = ArrayVec::new();
     for _ in 0..N {
-        assert!(vec.push(1u8).is_none());
+        assert!(vec.try_push(1u8).is_ok());
     }
-    assert!(vec.push(0).is_some());
+    assert!(vec.try_push(0).is_err());
     assert_eq!(vec.len(), N);
 }
 
@@ -78,7 +78,9 @@ fn test_drop() {
         array.push(vec![Bump(flag)]);
         array.push(vec![Bump(flag), Bump(flag)]);
         array.push(vec![]);
-        array.push(vec![Bump(flag)]);
+        let push4 = array.try_push(vec![Bump(flag)]);
+        assert_eq!(flag.get(), 0);
+        drop(push4);
         assert_eq!(flag.get(), 1);
         drop(array.pop());
         assert_eq!(flag.get(), 1);
@@ -218,7 +220,7 @@ fn test_drop_panic_into_iter() {
 #[test]
 fn test_insert() {
     let mut v = ArrayVec::from([]);
-    assert_eq!(v.push(1), Some(1));
+    assert_matches!(v.try_push(1), Err(_));
     assert_matches!(v.try_insert(0, 1), Err(_));
 
     let mut v = ArrayVec::<[_; 3]>::new();


### PR DESCRIPTION
## `push, insert` etc

With the goal of making arrayvec more of a "drop-in" for Vec, we realign the signatures methods `.push(elt), .insert(index, elt)` and `.remove(index)`.

```rust
pub fn push(&mut self, element: A::Item);
pub fn insert(&mut self, index: usize, element: A::Item);
pub fn remove(&mut self, index: usize) -> A::Item;
pub fn swap_remove(&mut self, index: usize) -> A::Item;
```

## `try_push` etc

Mimicing something like fallible allocation, we have the fallible new methods:

```rust
pub fn try_push(&mut self, element: A::Item) -> Result<(), CapacityError<A::Item>>;
pub fn try_insert(&mut self, index: usize, element: A::Item) -> Result<(), CapacityError<A::Item>>;
```

Notice that `try_insert` still panics if `index` is out of bounds.

## `pop_at` etc

Mimicing `.pop()`, we have new “checked” versions of `remove, swap_remove`:

```rust
pub fn pop_at(&mut self, index: usize) -> Option<A::Item>;
pub fn swap_pop(&mut self, index: usize) -> Option<A::Item>;
```

The rationale is: indexing out of bounds is not a regular runtime error, it's normally a contract violation. So when we introduce checked versions of such API, then we get “*checked*” versions that return `Option`. Non-presence is not necessarily an error.

## `ArrayString::push` etc

- ArrayString: push, push_str now have the same signature as corresponding on String. New methods try_push, try_push_str.

```rust
pub fn push(&mut self, c: char);
pub fn try_push(&mut self, c: char) -> Result<(), CapacityError<char>>;
pub fn push_str(&mut self, s: &str);
pub fn try_push_str<'a>(&mut self, s: &'a str) -> Result<(), CapacityError<&'a str>>;
```

Closes #46 
Closes #45

## Miscellaneous Changes

- odds is no longer a public dependency. We want the flexibility of dropping/upgrading this dep at will
- Rust version changes