### PR TITLE
Prepare 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - FEATURES='serde-1'
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.14.0
     - rust: stable
       env:
         - NODEFAULT=1

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,23 @@ __ https://bluss.github.io/arrayvec
 Recent Changes (arrayvec)
 -------------------------
 
+- 0.4.0
+
+  - Reformed signatures and error handling by @bluss and @tbu-:
+
+    - ``ArrayVec``'s ``push, insert, remove, swap_remove`` now match ``Vec``'s
+      corresponding signature and panic on capacity errors where applicable.
+    - Add fallible methods ``try_push, insert`` and checked methods
+      ``pop_at, swap_pop``.
+    - Similar changes to ``ArrayString``'s push methods.
+
+  - Use internal version of ``RangeArgument`` trait
+  - Add array sizes 50, 150, 200 by @daboross
+  - Support serde 1.0 by @daboross
+  - New method ``.push_unchecked()`` by @niklasf
+  - ``ArrayString`` implements ``PartialOrd, Ord`` by @tbu-
+  - Require Rust 1.15
+
 - 0.3.21
 
   - Use ``encode_utf8`` from crate odds

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,15 @@ Recent Changes (arrayvec)
   - ``ArrayString`` implements ``PartialOrd, Ord`` by @tbu-
   - Require Rust 1.15
 
+- 0.3.23
+
+  - Implement ``PartialOrd, Ord`` as well as ``PartialOrd<str>`` for
+    ``ArrayString``.
+
+- 0.3.22
+
+  - Implement ``Array`` for the 65536 size
+
 - 0.3.21
 
   - Use ``encode_utf8`` from crate odds

--- a/src/array.rs
+++ b/src/array.rs
@@ -46,6 +46,13 @@ impl Index for u16 {
     fn from(ix: usize) ->  Self { ix as u16 }
 }
 
+impl Index for u32 {
+    #[inline(always)]
+    fn to_usize(self) -> usize { self as usize }
+    #[inline(always)]
+    fn from(ix: usize) ->  Self { ix as u32 }
+}
+
 impl Index for usize {
     #[inline(always)]
     fn to_usize(self) -> usize { self }
@@ -80,4 +87,5 @@ fix_array_impl_recursive!(u8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 
                           16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
                           32, 40, 48, 50, 56, 64, 72, 96, 100, 128, 160, 192, 200, 224,);
 fix_array_impl_recursive!(u16, 256, 384, 512, 768, 1024, 2048, 4096, 8192, 16384, 32768,);
+fix_array_impl_recursive!(u32, 1 << 16,);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Rust Version
 //!
-//! This version of arrayvec requires Rust 1.15 or later.
+//! This version of arrayvec requires Rust 1.14 or later.
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.4/")]
 #![cfg_attr(not(feature="std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,16 @@
 //!
 //! - `std`
 //!   - Optional, enabled by default
-//!   - Use libstd
+//!   - Use libstd; disable to use `no_std` instead.
 //!
 //! - `use_union`
 //!   - Optional
 //!   - Requires Rust nightly channel
+//!   - Experimental: This flag uses nightly so it may break unexpectedly
+//!     at some point; since it doesn't change API this flag may also change
+//!     to do nothing in the future.
 //!   - Use the unstable feature untagged unions for the internal implementation,
-//!     which has reduced space overhead
+//!     which may have reduced space overhead
 //!
 //! ## Rust Version
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! This version of arrayvec requires Rust 1.15 or later.
 //!
-#![doc(html_root_url="https://docs.rs/arrayvec/0.3/")]
+#![doc(html_root_url="https://docs.rs/arrayvec/0.4/")]
 #![cfg_attr(not(feature="std"), no_std)]
 extern crate odds;
 extern crate nodrop;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -450,3 +450,9 @@ fn test_pop_at() {
     assert_eq!(v.pop_at(2), None);
     assert_eq!(&v[..], &["a", "d"]);
 }
+
+#[test]
+fn test_sizes() {
+    let v = ArrayVec::from([0u8; 1 << 16]);
+    assert_eq!(vec![0u8; v.len()], &v[..]);
+}


### PR DESCRIPTION
I think everything is finally ready to go.

It's hard to pick any particular minimal Rust version (1.15 picked now). We don't want to ignore everyone who is a few versions behind, but we also don't want to get into the hole that was requiring Rust 1.2 ever again.