### PR TITLE
Improve .extend() performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ version = "1.0"
 
 [dev-dependencies]
 matches = { version = "0.1" }
+bencher = "0.1.4"
+
+[[bench]]
+name = "extend"
+harness = false
 
 [features]
 default = ["std"]

--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -1,0 +1,43 @@
+
+extern crate arrayvec;
+#[macro_use] extern crate bencher;
+
+use arrayvec::ArrayVec;
+
+use bencher::Bencher;
+
+fn extend_with_constant(b: &mut Bencher) {
+    let mut v = ArrayVec::<[u8; 512]>::new();
+    let cap = v.capacity();
+    b.iter(|| {
+        v.clear();
+        v.extend((0..cap).map(|_| 1));
+        v[0]
+    });
+    b.bytes = v.capacity() as u64;
+}
+
+fn extend_with_range(b: &mut Bencher) {
+    let mut v = ArrayVec::<[u8; 512]>::new();
+    let cap = v.capacity();
+    b.iter(|| {
+        v.clear();
+        v.extend((0..cap).map(|x| x as _));
+        v[0]
+    });
+    b.bytes = v.capacity() as u64;
+}
+
+fn extend_with_slice(b: &mut Bencher) {
+    let mut v = ArrayVec::<[u8; 512]>::new();
+    let data = [1; 512];
+    b.iter(|| {
+        v.clear();
+        v.extend(data.iter().cloned());
+        v[0]
+    });
+    b.bytes = v.capacity() as u64;
+}
+
+benchmark_group!(benches, extend_with_constant, extend_with_range, extend_with_slice);
+benchmark_main!(benches);


### PR DESCRIPTION
We have to use the "SetLenOnDrop" pattern (see stdlib Vec) here.

Keep the length in a separate variable, write it back on scope exit. To
help the compiler with alias analysis and stuff.  We update the length
to handle panic in the iteration of the user's iterator, without
dropping any elements on the floor.

Note: This code was tested without the scope guard using the new option
-Zmutable-noalias, which had no effect here.

benchmark:

```
 name                  before.txt ns/iter  after.txt ns/iter  diff ns/iter   diff %
 extend_with_constant  280 (1828 MB/s)     74 (6918 MB/s)             -206  -73.57%
 extend_with_range     1,285 (398 MB/s)    979 (522 MB/s)             -306  -23.81%
 extend_with_slice     29 (17655 MB/s)     14 (36571 MB/s)             -15  -51.72%
```

cc discussion in #72 