### PR TITLE
nodrop: Remove odds dependency

### DIFF
--- a/nodrop/Cargo.toml
+++ b/nodrop/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 
 # Default, requires Rust 1.6+ to disable
 # Use libstd
-std = ["odds/std"]
+std = []
 
 # Optional, Rust 1.21.0
 # Use `needs_drop` to skip overwriting if not necessary
@@ -25,10 +25,6 @@ use_needs_drop = []
 
 # Optional, nightly channel
 use_union = ["nodrop-union"]
-
-[dependencies.odds]
-version = "0.2.12"
-default-features = false
 
 [dependencies.nodrop-union]
 path = "../nodrop-union"

--- a/nodrop/src/lib.rs
+++ b/nodrop/src/lib.rs
@@ -19,9 +19,6 @@
 #[cfg(not(any(test, feature="std")))]
 extern crate core as std;
 
-#[cfg(not(feature = "use_union"))]
-extern crate odds;
-
 #[cfg(feature = "use_union")]
 extern crate nodrop_union as imp;
 
@@ -30,7 +27,6 @@ pub use imp::NoDrop;
 
 #[cfg(not(feature = "use_union"))]
 mod imp {
-    use odds::debug_assert_unreachable;
     use std::ptr;
     use std::mem;
     use std::ops::{Deref, DerefMut};
@@ -124,6 +120,14 @@ mod imp {
         // as Option would do.
         assert!(mem::size_of::<Flag<&i32>>() > mem::size_of::<&i32>());
         assert!(mem::size_of::<Flag<Vec<i32>>>() > mem::size_of::<Vec<i32>>());
+    }
+
+    // copying this code saves us microcrate deps
+    #[inline]
+    unsafe fn debug_assert_unreachable() -> ! {
+        debug_assert!(false, "Reached unreachable section: this is a bug!");
+        enum Void { }
+        match *(1 as *const Void) { }
     }
 }
 


### PR DESCRIPTION
Copy in some code in an effort to avoid odds dependency in nodrop.

We could depend on crate unreachable, but it in turn depends on crate void, and that's a bit excessive.

cc #73 