### PR TITLE
Support Rust 1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - FEATURES='serde-1'
 matrix:
   include:
-    - rust: 1.14.0
+    - rust: 1.13.0
     - rust: stable
       env:
         - NODEFAULT=1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ## Rust Version
 //!
-//! This version of arrayvec requires Rust 1.14 or later.
+//! This version of arrayvec requires Rust 1.13 or later.
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.4/")]
 #![cfg_attr(not(feature="std"), no_std)]


### PR DESCRIPTION
Hi!  First of all, thank you for maintaining this wonderful library!

Currently, `arrayvec` is used by [`crossbeam-epoch`](https://github.com/crossbeam-rs/crossbeam-epoch), which is a concurrency library.  We Crossbeam developers aim to [push it](https://github.com/rayon-rs/rayon/pull/480) to [`rayon`](https://github.com/rayon-rs/rayon), which is a parallelism library.

But `rayon` should support Rust 1.12, and `arrayvec` currently doesn't.  May I ask if you could merge this PR so that `arrayvec` can be compiled in Rust 1.12.1, and in turn `rayon` can depend on `crossbeam-epoch`?

(I agree that the original code is clearer and more idiomatic..  I'm sorry for asking an ugly change.)