### PR TITLE
FIX: Fix future compat warning with pointer casts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ impl<A: Array> ArrayVec<A> {
         unsafe { // infallible
             // The spot to put the new value
             {
-                let p = self.get_unchecked_mut(index) as *mut _;
+                let p: *mut _ = self.get_unchecked_mut(index);
                 // Shift everything over to make space. (Duplicating the
                 // `index`th element into two consecutive places.)
                 ptr::copy(p, p.offset(1), len - index);


### PR DESCRIPTION
```
warning: the type of this value must be known in this context
   --> src/lib.rs:312:32
    |
312 |                 ptr::copy(p, p.offset(1), len - index);
    |                                ^^^^^^
    |
    = note: #[warn(tyvar_behind_raw_pointer)] on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
```