### PR TITLE
Implement a careful “MaybeUninit” using ManuallyDrop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
 matrix:
   include:
     - rust: 1.13.0
+    - rust: 1.19.0
+    - rust: 1.20.0
     - rust: stable
       env:
         - NODEFAULT=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/bluss/arrayvec"
 keywords = ["stack", "vector", "array", "data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
+[build-dependencies]
+version_check = "0.1"
+
 [dependencies]
 nodrop = { version = "0.1.12", path = "nodrop", default-features = false }
 
@@ -37,8 +40,10 @@ harness = false
 [features]
 default = ["std"]
 std = []
-use_union = []
 serde-1 = ["serde"]
+
+# has no effect
+use_union = []
 
 [package.metadata.docs.rs]
 features = ["serde-1"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+
+//!
+//! This build script detects if we have new enough Rust
+//!
+
+extern crate version_check;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if let Some((true, _)) = version_check::is_min_version("1.20.0") {
+        println!("cargo:rustc-cfg=has_manuallydrop");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,6 @@
 //!   - Optional, enabled by default
 //!   - Use libstd; disable to use `no_std` instead.
 //!
-//! - `use_union`
-//!   - Optional
-//!   - Requires Rust nightly channel
-//!   - Experimental: This flag uses nightly so it *may break* unexpectedly
-//!     at some point; since it doesn't change API this flag may also change
-//!     to do nothing in the future.
-//!   - Use the unstable feature untagged unions for the internal implementation,
-//!     which may have reduced space overhead
 //! - `serde-1`
 //!   - Optional
 //!   - Enable serialization for ArrayVec and ArrayString using serde 1.0
@@ -25,6 +17,7 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.4/")]
 #![cfg_attr(not(feature="std"), no_std)]
+
 extern crate nodrop;
 #[cfg(feature="serde-1")]
 extern crate serde;
@@ -50,11 +43,16 @@ use std::fmt;
 #[cfg(feature="std")]
 use std::io;
 
-#[cfg(not(feature="use_union"))]
-use nodrop::NoDrop;
 
-#[cfg(feature="use_union")]
-use std::mem::ManuallyDrop as NoDrop;
+#[cfg(has_manuallydrop)]
+mod maybe_uninit;
+#[cfg(has_manuallydrop)]
+use maybe_uninit::MaybeUninit;
+
+#[cfg(not(has_manuallydrop))]
+mod maybe_uninit_nodrop;
+#[cfg(not(has_manuallydrop))]
+use maybe_uninit_nodrop::MaybeUninit;
 
 #[cfg(feature="serde-1")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
@@ -93,7 +91,7 @@ unsafe fn new_array<A: Array>() -> A {
 ///
 /// ArrayVec can be converted into a by value iterator.
 pub struct ArrayVec<A: Array> {
-    xs: NoDrop<A>,
+    xs: MaybeUninit<A>,
     len: A::Index,
 }
 
@@ -130,7 +128,7 @@ impl<A: Array> ArrayVec<A> {
     /// ```
     pub fn new() -> ArrayVec<A> {
         unsafe {
-            ArrayVec { xs: NoDrop::new(new_array()), len: Index::from(0) }
+            ArrayVec { xs: MaybeUninit::uninitialized(), len: Index::from(0) }
         }
     }
 
@@ -574,7 +572,7 @@ impl<A: Array> ArrayVec<A> {
             Err(self)
         } else {
             unsafe {
-                let array = ptr::read(&*self.xs);
+                let array = ptr::read(self.xs.ptr());
                 mem::forget(self);
                 Ok(array)
             }
@@ -603,7 +601,7 @@ impl<A: Array> Deref for ArrayVec<A> {
     #[inline]
     fn deref(&self) -> &[A::Item] {
         unsafe {
-            slice::from_raw_parts(self.xs.as_ptr(), self.len())
+            slice::from_raw_parts((*self.xs.ptr()).as_ptr(), self.len())
         }
     }
 }
@@ -613,7 +611,7 @@ impl<A: Array> DerefMut for ArrayVec<A> {
     fn deref_mut(&mut self) -> &mut [A::Item] {
         let len = self.len();
         unsafe {
-            slice::from_raw_parts_mut(self.xs.as_mut_ptr(), len)
+            slice::from_raw_parts_mut((*self.xs.ptr_mut()).as_mut_ptr(), len)
         }
     }
 }
@@ -629,7 +627,7 @@ impl<A: Array> DerefMut for ArrayVec<A> {
 /// ```
 impl<A: Array> From<A> for ArrayVec<A> {
     fn from(array: A) -> Self {
-        ArrayVec { xs: NoDrop::new(array), len: Index::from(A::capacity()) }
+        ArrayVec { xs: MaybeUninit::from(array), len: Index::from(A::capacity()) }
     }
 }
 

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -1,0 +1,34 @@
+
+
+use std::mem::ManuallyDrop;
+use std::mem::uninitialized;
+
+/// A combination of ManuallyDrop and “maybe uninitialized”;
+/// this wraps a value that can be wholly or partially uninitialized;
+/// it also has no drop regardless of the type of T.
+pub struct MaybeUninit<T>(ManuallyDrop<T>);
+
+impl<T> MaybeUninit<T> {
+    /// Create a new MaybeUninit with uninitialized interior
+    pub unsafe fn uninitialized() -> Self {
+        Self::from(uninitialized())
+    }
+
+    /// Create a new MaybeUninit from the value `v`.
+    pub fn from(v: T) -> Self {
+        MaybeUninit(ManuallyDrop::new(v))
+    }
+
+    /// Return a raw pointer to the interior
+    pub fn ptr(&self) -> *const T {
+        (&self.0) as *const ManuallyDrop<_> as *const T
+    }
+
+    /// Return a raw pointer to the interior (mutable)
+    pub fn ptr_mut(&mut self) -> *mut T {
+        (&mut self.0) as *mut ManuallyDrop<_> as *mut T
+    }
+}
+
+
+

--- a/src/maybe_uninit_nodrop.rs
+++ b/src/maybe_uninit_nodrop.rs
@@ -1,0 +1,33 @@
+
+
+use nodrop::NoDrop;
+use std::mem::uninitialized;
+
+/// A combination of NoDrop and “maybe uninitialized”;
+/// this wraps a value that can be wholly or partially uninitialized.
+pub struct MaybeUninit<T>(NoDrop<T>);
+
+impl<T> MaybeUninit<T> {
+    /// Create a new MaybeUninit with uninitialized interior
+    pub unsafe fn uninitialized() -> Self {
+        Self::from(uninitialized())
+    }
+
+    /// Create a new MaybeUninit from the value `v`.
+    pub fn from(v: T) -> Self {
+        MaybeUninit(NoDrop::new(v))
+    }
+
+    /// Return a raw pointer to the interior
+    pub fn ptr(&self) -> *const T {
+        &**(&self.0)
+    }
+
+    /// Return a raw pointer to the interior (mutable)
+    pub fn ptr_mut(&mut self) -> *mut T {
+        &mut **(&mut self.0)
+    }
+}
+
+
+


### PR DESCRIPTION
This is a cautious version of MaybeUninit, since we don't have one in
libstd, based on ManuallyDrop.

This moves ArrayVec to a nice, no size overhead implementation by
default. We use Rust version sniffing (build script) to automatically
use this for new enough Rust versions.

This doesn't kill nodrop unfortunately, it still remains as the
fallback.