### PR TITLE
Fix just a few stacked borrow issues, and improve extend performance

### DIFF
--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -5,6 +5,7 @@ extern crate arrayvec;
 use arrayvec::ArrayVec;
 
 use bencher::Bencher;
+use bencher::black_box;
 
 fn extend_with_constant(b: &mut Bencher) {
     let mut v = ArrayVec::<[u8; 512]>::new();
@@ -33,7 +34,7 @@ fn extend_with_slice(b: &mut Bencher) {
     let data = [1; 512];
     b.iter(|| {
         v.clear();
-        v.extend(data.iter().cloned());
+        v.extend(black_box(data.iter()).cloned());
         v[0]
     });
     b.bytes = v.capacity() as u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,11 +461,11 @@ impl<A: Array> ArrayVec<A> {
     /// array.truncate(4);
     /// assert_eq!(&array[..], &[1, 2, 3]);
     /// ```
-    pub fn truncate(&mut self, len: usize) {
+    pub fn truncate(&mut self, new_len: usize) {
         unsafe {
-            if len < self.len() {
-                let tail: *mut [_] = &mut self[len..];
-                self.set_len(len);
+            if new_len < self.len() {
+                let tail: *mut [_] = &mut self[new_len..];
+                self.len = Index::from(new_len);
                 ptr::drop_in_place(tail);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,10 +890,10 @@ impl<A: Array> Extend<A::Item> for ArrayVec<A> {
             // We update the length to handle panic in the iteration of the
             // user's iterator, without dropping any elements on the floor.
             let mut guard = ScopeExitGuard {
-                value: self,
+                value: &mut self.len,
                 data: len,
-                f: |&len, self_| {
-                    self_.set_len(len)
+                f: move |&len, self_len| {
+                    **self_len = Index::from(len);
                 }
             };
             for elt in iter.into_iter().take(take) {


### PR DESCRIPTION
Extend: This simplification -- borrowing self.len instead of self, leads to
an improvement in the extend_from_slice benchmark.

It's also guided by the discussion of stacked borrows; the old code
would be invalid, because the whole self is borrowed while ptr is derived from
self.

In truncate, don't access self while holding raw pointer derived from self

Again, stacked borrows model makes the `self.set_len()` call illegal
because we are holding (and are going to use) another raw pointer
derived from self, `tail`.


bench comparison for extend. Caveat might be that optimization can also be influenced by how the code can be optimized in the benchmark.

```
 name                  63 ns/iter       62 ns/iter       diff ns/iter   diff % 
 extend_with_constant  290 (1765 MB/s)  296 (1729 MB/s)             6    2.07% 
 extend_with_range     288 (1777 MB/s)  287 (1783 MB/s)            -1   -0.35% 
 extend_with_slice     828 (618 MB/s)   218 (2348 MB/s)          -610  -73.67%
```