### PR TITLE
Improve .extend() performance (?)

### DIFF
--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -2,6 +2,8 @@
 extern crate arrayvec;
 #[macro_use] extern crate bencher;
 
+use std::io::Write;
+
 use arrayvec::ArrayVec;
 
 use bencher::Bencher;
@@ -12,8 +14,9 @@ fn extend_with_constant(b: &mut Bencher) {
     let cap = v.capacity();
     b.iter(|| {
         v.clear();
-        v.extend((0..cap).map(|_| 1));
-        v[0]
+        let constant = black_box(1);
+        v.extend((0..cap).map(move |_| constant));
+        v[511]
     });
     b.bytes = v.capacity() as u64;
 }
@@ -23,8 +26,9 @@ fn extend_with_range(b: &mut Bencher) {
     let cap = v.capacity();
     b.iter(|| {
         v.clear();
-        v.extend((0..cap).map(|x| x as _));
-        v[0]
+        let range = 0..cap;
+        v.extend(range.map(|x| black_box(x as _)));
+        v[511]
     });
     b.bytes = v.capacity() as u64;
 }
@@ -34,8 +38,20 @@ fn extend_with_slice(b: &mut Bencher) {
     let data = [1; 512];
     b.iter(|| {
         v.clear();
-        v.extend(black_box(data.iter()).cloned());
-        v[0]
+        let iter = data.iter().map(|&x| x);
+        v.extend(iter);
+        v[511]
+    });
+    b.bytes = v.capacity() as u64;
+}
+
+fn extend_with_write(b: &mut Bencher) {
+    let mut v = ArrayVec::<[u8; 512]>::new();
+    let data = [1; 512];
+    b.iter(|| {
+        v.clear();
+        v.write(&data[..]).ok();
+        v[511]
     });
     b.bytes = v.capacity() as u64;
 }
@@ -51,5 +67,12 @@ fn extend_from_slice(b: &mut Bencher) {
     b.bytes = v.capacity() as u64;
 }
 
-benchmark_group!(benches, extend_with_constant, extend_with_range, extend_with_slice, extend_from_slice);
+benchmark_group!(benches,
+                 extend_with_constant,
+                 extend_with_range,
+                 extend_with_slice,
+                 extend_with_write,
+                 extend_from_slice
+);
+
 benchmark_main!(benches);


### PR DESCRIPTION
cc #101 

I'm experimenting with different formulations. Both the existing and this pr's implementations can compile into a memcpy, like they should, if the input is a cloned slice iterator. The main difficulty seems to be to make a good benchmark. Without "black_box"es, the benchmarks compile out (and that's normally a good sign in itself, the code is then transparent to the optimizer) and with too many black box calls, the optimizations are disabled.