### PR TITLE
Implement a "MaybeUninit" and use it conditionally (0.4.x version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,16 @@ matrix:
     - rust: nightly
       env:
         - NODEFAULT=1
+        - ARRAYVECTEST_ENSURE_UNION=1
     - rust: nightly
       env:
       - NODROP_FEATURES='use_needs_drop'
+      - ARRAYVECTEST_ENSURE_UNION=1
     - rust: nightly
       env:
       - FEATURES='serde use_union'
       - NODROP_FEATURES='use_union'
+      - ARRAYVECTEST_ENSURE_UNION=1
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/bluss/arrayvec"
 keywords = ["stack", "vector", "array", "data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
+[build-dependencies]
+
 [dependencies]
 nodrop = { version = "0.1.12", path = "nodrop", default-features = false }
 
@@ -37,11 +39,13 @@ harness = false
 [features]
 default = ["std"]
 std = []
-use_union = []
 serde-1 = ["serde"]
 
 array-sizes-33-128 = []
 array-sizes-129-255 = []
+
+# has no effect
+use_union = []
 
 [package.metadata.docs.rs]
 features = ["serde-1"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,79 @@
+
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn main() {
+    // we need to output *some* file to opt out of the default
+    println!("cargo:rerun-if-changed=build.rs");
+
+    detect_maybe_uninit();
+}
+
+fn detect_maybe_uninit() {
+    let has_unstable_union_with_md = probe(&maybe_uninit_code(true));
+    if has_unstable_union_with_md {
+        println!("cargo:rustc-cfg=has_manually_drop_in_union");
+        println!("cargo:rustc-cfg=has_union_feature");
+        return;
+    }
+
+    let has_stable_union_with_md = probe(&maybe_uninit_code(false));
+    if has_stable_union_with_md {
+        println!("cargo:rustc-cfg=has_manually_drop_in_union");
+    }
+}
+
+// To guard against changes in this currently unstable feature, use
+// a detection tests instead of a Rustc version and/or date test.
+fn maybe_uninit_code(use_feature: bool) -> String {
+    let feature = if use_feature { "#![feature(untagged_unions)]" } else { "" };
+
+    let code = "
+    #![allow(warnings)]
+    use std::mem::ManuallyDrop;
+
+    #[derive(Copy)]
+    pub union MaybeUninit<T> {
+        empty: (),
+        value: ManuallyDrop<T>,
+    }
+
+    impl<T> Clone for MaybeUninit<T> where T: Copy
+    {
+        fn clone(&self) -> Self { *self }
+    }
+
+    fn main() {
+        let value1 = MaybeUninit::<[i32; 3]> { empty: () };
+        let value2 = MaybeUninit { value: ManuallyDrop::new([1, 2, 3]) };
+    }
+    ";
+
+
+    [feature, code].concat()
+}
+
+/// Test if a code snippet can be compiled
+fn probe(code: &str) -> bool {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let out_dir = env::var_os("OUT_DIR").expect("environment variable OUT_DIR");
+
+    let mut child = Command::new(rustc)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--emit=obj")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("rustc probe");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("rustc stdin")
+        .write_all(code.as_bytes())
+        .expect("write rustc stdin");
+
+    child.wait().expect("rustc probe").success()
+}

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -26,6 +26,7 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// if needed.
 #[derive(Copy)]
 pub struct ArrayString<A: Array<Item=u8>> {
+    // FIXME: Use Copyable union for xs when we can
     xs: A,
     len: A::Index,
 }
@@ -53,7 +54,8 @@ impl<A: Array<Item=u8>> ArrayString<A> {
     pub fn new() -> ArrayString<A> {
         unsafe {
             ArrayString {
-                xs: ::new_array(),
+                // FIXME: Use Copyable union for xs when we can
+                xs: mem::zeroed(),
                 len: Index::from(0),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,14 +74,6 @@ pub use array_string::ArrayString;
 pub use errors::CapacityError;
 
 
-unsafe fn new_array<A: Array>() -> A {
-    // Note: Returning an uninitialized value here only works
-    // if we can be sure the data is never used. The nullable pointer
-    // inside enum optimization conflicts with this this for example,
-    // so we need to be extra careful. See `NoDrop` enum.
-    mem::uninitialized()
-}
-
 /// A vector with a fixed capacity.
 ///
 /// The `ArrayVec` is a vector backed by a fixed size array. It keeps track of

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -1,0 +1,51 @@
+
+
+use array::Array;
+use std::mem::ManuallyDrop;
+
+/// A combination of ManuallyDrop and “maybe uninitialized”;
+/// this wraps a value that can be wholly or partially uninitialized;
+/// it also has no drop regardless of the type of T.
+#[derive(Copy)]
+pub union MaybeUninit<T> {
+    empty: (),
+    value: ManuallyDrop<T>,
+}
+// Why we don't use std's MaybeUninit on nightly? See the ptr method
+
+impl<T> Clone for MaybeUninit<T> where T: Copy
+{
+    fn clone(&self) -> Self { *self }
+}
+
+impl<T> MaybeUninit<T> {
+    /// Create a new MaybeUninit with uninitialized interior
+    pub unsafe fn uninitialized() -> Self {
+        MaybeUninit { empty: () }
+    }
+
+    /// Create a new MaybeUninit from the value `v`.
+    pub fn from(v: T) -> Self {
+        MaybeUninit { value: ManuallyDrop::new(v) }
+    }
+
+    // Raw pointer casts written so that we don't reference or access the
+    // uninitialized interior value
+
+    /// Return a raw pointer to the start of the interior array
+    pub fn ptr(&self) -> *const T::Item
+        where T: Array
+    {
+        // std MaybeUninit creates a &self.value reference here which is
+        // not guaranteed to be sound in our case - we will partially
+        // initialize the value, not always wholly.
+        self as *const _ as *const T::Item
+    }
+
+    /// Return a mut raw pointer to the start of the interior array
+    pub fn ptr_mut(&mut self) -> *mut T::Item
+        where T: Array
+    {
+        self as *mut _ as *mut T::Item
+    }
+}

--- a/src/maybe_uninit_nodrop.rs
+++ b/src/maybe_uninit_nodrop.rs
@@ -1,0 +1,41 @@
+
+use array::Array;
+use nodrop::NoDrop;
+use std::mem::uninitialized;
+
+/// A combination of NoDrop and “maybe uninitialized”;
+/// this wraps a value that can be wholly or partially uninitialized.
+///
+/// NOTE: This is known to not be a good solution, but it's the one we have kept
+/// working on stable Rust. Stable improvements are encouraged, in any form,
+/// but of course we are waiting for a real, stable, MaybeUninit.
+pub struct MaybeUninit<T>(NoDrop<T>);
+// why don't we use ManuallyDrop here: It doesn't inhibit
+// enum layout optimizations that depend on T, and we support older Rust.
+
+impl<T> MaybeUninit<T> {
+    /// Create a new MaybeUninit with uninitialized interior
+    pub unsafe fn uninitialized() -> Self {
+        Self::from(uninitialized())
+    }
+
+    /// Create a new MaybeUninit from the value `v`.
+    pub fn from(v: T) -> Self {
+        MaybeUninit(NoDrop::new(v))
+    }
+
+    /// Return a raw pointer to the start of the interior array
+    pub fn ptr(&self) -> *const T::Item
+        where T: Array
+    {
+        &*self.0 as *const T as *const _
+    }
+
+    /// Return a mut raw pointer to the start of the interior array
+    pub fn ptr_mut(&mut self) -> *mut T::Item
+        where T: Array
+    {
+        &mut *self.0 as *mut T as *mut _
+    }
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -508,3 +508,12 @@ fn test_sizes_129_255() {
     ArrayVec::from([0u8; 255]);
 }
 
+
+#[test]
+fn test_nightly_uses_maybe_uninit() {
+    if option_env!("ARRAYVECTEST_ENSURE_UNION").map(|s| !s.is_empty()).unwrap_or(false) {
+        assert!(cfg!(has_manually_drop_in_union));
+        type ByteArray = ArrayVec<[u8; 4]>;
+        assert!(mem::size_of::<ByteArray>() == 5);
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -165,6 +165,14 @@ fn test_compact_size() {
 }
 
 #[test]
+fn test_still_works_with_option_arrayvec() {
+    type RefArray = ArrayVec<[&'static i32; 2]>;
+    let array = Some(RefArray::new());
+    assert!(array.is_some());
+    println!("{:?}", array);
+}
+
+#[test]
 fn test_drain() {
     let mut v = ArrayVec::from([0; 8]);
     v.pop();


### PR DESCRIPTION
This change is for the 0.4.x release series of arrayvec,
not master.

**Implement a "MaybeUninit" and use it conditionally**

Use a build script to detect if we can use MaybeUninit or NoDrop.
Enabling unstable features automatically is not ideal, but since it's
a soundness issue we should do it.

Use a MaybeUninit-like union on nightly when we can. We use a feature
detection script in build.rs, so that we also go back to the fallback if
the unstable feature changes in an unexpected way.

We need to continue to use NoDrop for best working stable
implementation, but we eagerly use our union solution where we can,
currently only in nightlies.

Rustc feature probe code written by @cuviper, taken from num-bigint.

**Remove use of uninitialized in ArrayString**

We can't fix this properly (MaybeUninit with a union) until we change
the user visible API (we need to require that A: Copy.

As a temporary solution for arrayvec version 0.4.*, we use zeroed to
initialize an array of bytes, instead of using uninitialized. This may
have a negative performance impact, but the fix is to upgrade to future
arrayvec 0.5.

This also changes the `use_union` feature to do nothing. This is
allowed, as has been indicated in the feature description in docs.

There are no user visible API changes but the size of ArrayVec types may
change due to the enabling of the MaybeUninit feature.

Closes #86 (now obsolete)