### PR TITLE
Implement FromStr for ArrayString

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -5,6 +5,7 @@ use std::hash::{Hash, Hasher};
 use std::ptr;
 use std::ops::{Deref, DerefMut};
 use std::str;
+use std::str::FromStr;
 use std::str::Utf8Error;
 use std::slice;
 
@@ -504,6 +505,16 @@ impl<A> Ord for ArrayString<A>
 {
     fn cmp(&self, rhs: &Self) -> cmp::Ordering {
         (**self).cmp(&**rhs)
+    }
+}
+
+impl<A> FromStr for ArrayString<A>
+    where A: Array<Item=u8> + Copy
+{
+    type Err = CapacityError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from(s).map_err(CapacityError::simplify)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -488,6 +488,14 @@ fn test_string_from() {
 }
 
 #[test]
+fn test_string_parse_from_str() {
+    let text = "hello world";
+    let u: ArrayString<[_; 11]> = text.parse().unwrap();
+    assert_eq!(&u, text);
+    assert_eq!(u.len(), text.len());
+}
+
+#[test]
 fn test_string_from_bytes() {
     let text = "hello world";
     let u = ArrayString::from_byte_string(b"hello world").unwrap();


### PR DESCRIPTION
This is very useful for generic code that may want to parse
input strings into arbitrary other types, such as ArrayString.

Limitations of the FromStr trait don't allow us to keep the original string slice
inside the CapacityError, unfortunately.