### PR TITLE
Implement quickcheck::Arbitrary trait for ArrayVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ categories = ["data-structures", "no-std"]
 [dependencies]
 nodrop = { version = "0.1.12", path = "nodrop", default-features = false }
 
+[dependencies.rand]
+version = "0.6"
+optional = true
+
+[dependencies.quickcheck]
+version = "0.8"
+optional = true
+
 [dependencies.serde]
 version = "1.0"
 optional = true
@@ -40,6 +48,7 @@ harness = false
 default = ["std"]
 std = []
 serde-1 = ["serde"]
+quickcheck-1 = ["quickcheck","rand"]
 
 array-sizes-33-128 = []
 array-sizes-129-255 = []


### PR DESCRIPTION
When you use `ArrayVec` and `quickcheck`, it is really handy to have `Arbitrary` trait implemented for `ArrayVec` - trivial (and optional) change, but IMHO useful.