### PR TITLE
Combined fixes: Adjust inlining, and Fix usage of `get_unchecked_mut`.

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -87,10 +87,8 @@ macro_rules! fix_array_impl {
             type Index = $index_type;
             const CAPACITY: usize = $len;
             #[doc(hidden)]
-            #[inline]
             fn as_slice(&self) -> &[Self::Item] { self }
             #[doc(hidden)]
-            #[inline]
             fn as_mut_slice(&mut self) -> &mut [Self::Item] { self }
         }
     )

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -113,7 +113,7 @@ impl<A> ArrayString<A>
     /// let string = ArrayString::<[_; 3]>::new();
     /// assert_eq!(string.capacity(), 3);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn capacity(&self) -> usize { A::CAPACITY }
 
     /// Return if the `ArrayString` is completely filled.
@@ -244,7 +244,6 @@ impl<A> ArrayString<A>
     ///
     /// assert_eq!(s.pop(), None);
     /// ```
-    #[inline]
     pub fn pop(&mut self) -> Option<char> {
         let ch = match self.chars().rev().next() {
             Some(ch) => ch,
@@ -273,7 +272,6 @@ impl<A> ArrayString<A>
     /// string.truncate(4);
     /// assert_eq!(&string[..], "foo");
     /// ```
-    #[inline]
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
             assert!(self.is_char_boundary(new_len));
@@ -304,7 +302,6 @@ impl<A> ArrayString<A>
     /// assert_eq!(s.remove(1), 'o');
     /// assert_eq!(s.remove(0), 'o');
     /// ```
-    #[inline]
     pub fn remove(&mut self, idx: usize) -> char {
         let ch = match self[idx..].chars().next() {
             Some(ch) => ch,
@@ -336,7 +333,6 @@ impl<A> ArrayString<A>
     ///
     /// This method uses *debug assertions* to check the validity of `length`
     /// and may use other debug assertions.
-    #[inline]
     pub unsafe fn set_len(&mut self, length: usize) {
         debug_assert!(length <= self.capacity());
         self.len = Index::from(length);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl<A: Array> ArrayVec<A> {
     /// let array = ArrayVec::from([1, 2, 3]);
     /// assert_eq!(array.capacity(), 3);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn capacity(&self) -> usize { A::CAPACITY }
 
     /// Return if the `ArrayVec` is completely filled.
@@ -235,7 +235,6 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// assert_eq!(&array[..], &[1, 2]);
     /// ```
-    #[inline]
     pub unsafe fn push_unchecked(&mut self, element: A::Item) {
         let len = self.len();
         debug_assert!(len < A::CAPACITY);
@@ -507,7 +506,6 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// This method uses *debug assertions* to check that `length` is
     /// not greater than the capacity.
-    #[inline]
     pub unsafe fn set_len(&mut self, length: usize) {
         debug_assert!(length <= self.capacity());
         self.len = Index::from(length);
@@ -755,7 +753,6 @@ pub struct IntoIter<A: Array> {
 impl<A: Array> Iterator for IntoIter<A> {
     type Item = A::Item;
 
-    #[inline]
     fn next(&mut self) -> Option<A::Item> {
         if self.index == self.v.len {
             None
@@ -775,7 +772,6 @@ impl<A: Array> Iterator for IntoIter<A> {
 }
 
 impl<A: Array> DoubleEndedIterator for IntoIter<A> {
-    #[inline]
     fn next_back(&mut self) -> Option<A::Item> {
         if self.index == self.v.len {
             None
@@ -852,7 +848,6 @@ impl<'a, A: Array> Iterator for Drain<'a, A>
 {
     type Item = A::Item;
 
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|elt|
             unsafe {
@@ -861,7 +856,6 @@ impl<'a, A: Array> Iterator for Drain<'a, A>
         )
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
@@ -870,7 +864,6 @@ impl<'a, A: Array> Iterator for Drain<'a, A>
 impl<'a, A: Array> DoubleEndedIterator for Drain<'a, A>
     where A::Item: 'a,
 {
-    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|elt|
             unsafe {
@@ -1069,27 +1062,22 @@ impl<A: Array> Default for ArrayVec<A> {
 }
 
 impl<A: Array> PartialOrd for ArrayVec<A> where A::Item: PartialOrd {
-    #[inline]
     fn partial_cmp(&self, other: &ArrayVec<A>) -> Option<cmp::Ordering> {
         (**self).partial_cmp(other)
     }
 
-    #[inline]
     fn lt(&self, other: &Self) -> bool {
         (**self).lt(other)
     }
 
-    #[inline]
     fn le(&self, other: &Self) -> bool {
         (**self).le(other)
     }
 
-    #[inline]
     fn ge(&self, other: &Self) -> bool {
         (**self).ge(other)
     }
 
-    #[inline]
     fn gt(&self, other: &Self) -> bool {
         (**self).gt(other)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,7 +628,8 @@ impl<A: Array> ArrayVec<A> {
         }
     }
 
-    /// Dispose of `self` without the overwriting that is needed in Drop.
+    /// Dispose of `self` (same as drop)
+    #[deprecated="Use std::mem::drop instead, if at all needed."]
     pub fn dispose(mut self) {
         self.clear();
         mem::forget(self);


### PR DESCRIPTION
Adjust inlines using the following principles:

- Trivial methods (empty and simple constants) can be inline(always)
- Generic methods don't need any inlining directive at all.
  ..with the exception of Deref which just seems to be extra important.
- Non-generic items use #[inline] to enable inlining at the
  compiler's discretion.


Replace uses of <[T]>::get_unchecked_mut with raw pointer accessor

This is a soundness fix w.r.t unsafe coding guidelines.

In some of the instances, `get_unchecked_mut() -> &mut T as *mut T` was
used in places where the element was potentially uninitialized.

This was a problem in push. (Not a problem in IntoIter next/next_back,
where the whole range we're iterating is initialized).

