### PR TITLE
impl diesel::deserialize::FromSql for ArrayString

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,15 @@ default-features = false
 [dev-dependencies.serde_test]
 version = "1.0"
 
+[dependencies.diesel]
+version = "1.4"
+optional = true
+default-features = false
+
+[dev-dependencies.diesel]
+version = "1.4"
+features = ["sqlite"]
+
 [dev-dependencies]
 matches = { version = "0.1" }
 bencher = "0.1.4"

--- a/tests/diesel.rs
+++ b/tests/diesel.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "diesel")]
+#[macro_use]
+extern crate diesel;
+
+use arrayvec::ArrayString;
+use diesel::{prelude::*, sqlite::SqliteConnection, table};
+
+table! {
+    use diesel::sql_types::{Text, Integer};
+    texts {
+        id -> Integer,
+        body -> Text,
+    }
+}
+
+#[test]
+fn test_query() {
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+
+    diesel::sql_query("CREATE TABLE texts ( id INTEGER PRIMARY KEY, body TEXT NOT NULL )")
+        .execute(&conn)
+        .unwrap();
+
+    let body = "Answer to the Ultimate Question of Life, the Universe, and Everything";
+
+    diesel::insert_into(texts::table)
+        .values(&(texts::id.eq(42), texts::body.eq(body)))
+        .execute(&conn)
+        .unwrap();
+
+    let fetched_body = texts::table
+        .select(texts::body)
+        .load::<ArrayString<[u8; 128]>>(&conn)
+        .unwrap()[0];
+
+    assert_eq!(body, fetched_body.as_str());
+}


### PR DESCRIPTION
This PR adds support for `diesel`. With `diesel` feature flag, you can query `text` type field without any allocation. This is what I really wanted :)
If this feature is too much for `arrayvec` crate, I would like to create another crate. Thanks.