### PR TITLE
fix clippy lints and made documentation more readable

### DIFF
--- a/benches/arraystring.rs
+++ b/benches/arraystring.rs
@@ -1,6 +1,6 @@
-
 extern crate arrayvec;
-#[macro_use] extern crate bencher;
+#[macro_use]
+extern crate bencher;
 
 use arrayvec::ArrayString;
 
@@ -10,8 +10,7 @@ fn try_push_c(b: &mut Bencher) {
     let mut v = ArrayString::<[u8; 512]>::new();
     b.iter(|| {
         v.clear();
-        while v.try_push('c').is_ok() {
-        }
+        while v.try_push('c').is_ok() {}
         v.len()
     });
     b.bytes = v.capacity() as u64;
@@ -21,8 +20,7 @@ fn try_push_alpha(b: &mut Bencher) {
     let mut v = ArrayString::<[u8; 512]>::new();
     b.iter(|| {
         v.clear();
-        while v.try_push('α').is_ok() {
-        }
+        while v.try_push('α').is_ok() {}
         v.len()
     });
     b.bytes = v.capacity() as u64;
@@ -85,6 +83,13 @@ fn push_string(b: &mut Bencher) {
     b.bytes = v.capacity() as u64;
 }
 
-benchmark_group!(benches, try_push_c, try_push_alpha, try_push_string, push_c,
-                 push_alpha, push_string);
+benchmark_group!(
+    benches,
+    try_push_c,
+    try_push_alpha,
+    try_push_string,
+    push_c,
+    push_alpha,
+    push_string
+);
 benchmark_main!(benches);

--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -1,13 +1,13 @@
-
 extern crate arrayvec;
-#[macro_use] extern crate bencher;
+#[macro_use]
+extern crate bencher;
 
 use std::io::Write;
 
 use arrayvec::ArrayVec;
 
-use bencher::Bencher;
 use bencher::black_box;
+use bencher::Bencher;
 
 fn extend_with_constant(b: &mut Bencher) {
     let mut v = ArrayVec::<[u8; 512]>::new();
@@ -67,12 +67,13 @@ fn extend_from_slice(b: &mut Bencher) {
     b.bytes = v.capacity() as u64;
 }
 
-benchmark_group!(benches,
-                 extend_with_constant,
-                 extend_with_range,
-                 extend_with_slice,
-                 extend_with_write,
-                 extend_from_slice
+benchmark_group!(
+    benches,
+    extend_with_constant,
+    extend_with_range,
+    extend_with_slice,
+    extend_with_write,
+    extend_from_slice
 );
 
 benchmark_main!(benches);

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,4 +1,3 @@
-
 /// Trait for fixed size arrays.
 ///
 /// This trait is implemented for some specific array sizes, see
@@ -33,65 +32,93 @@ pub unsafe trait Array {
     fn as_mut_slice(&mut self) -> &mut [Self::Item];
 }
 
-pub trait Index : PartialEq + Copy {
+pub trait Index: PartialEq + Copy {
     fn to_usize(self) -> usize;
     fn from(_: usize) -> Self;
 }
 
 impl Index for () {
     #[inline(always)]
-    fn to_usize(self) -> usize { 0 }
+    fn to_usize(self) -> usize {
+        0
+    }
     #[inline(always)]
-    fn from(_ix: usize) ->  Self { () }
+    fn from(_ix: usize) -> Self {
+        ()
+    }
 }
 
 impl Index for bool {
     #[inline(always)]
-    fn to_usize(self) -> usize { self as usize }
+    fn to_usize(self) -> usize {
+        self as usize
+    }
     #[inline(always)]
-    fn from(ix: usize) ->  Self { ix != 0 }
+    fn from(ix: usize) -> Self {
+        ix != 0
+    }
 }
 
 impl Index for u8 {
     #[inline(always)]
-    fn to_usize(self) -> usize { self as usize }
+    fn to_usize(self) -> usize {
+        self as usize
+    }
     #[inline(always)]
-    fn from(ix: usize) ->  Self { ix as u8 }
+    fn from(ix: usize) -> Self {
+        ix as u8
+    }
 }
 
 impl Index for u16 {
     #[inline(always)]
-    fn to_usize(self) -> usize { self as usize }
+    fn to_usize(self) -> usize {
+        self as usize
+    }
     #[inline(always)]
-    fn from(ix: usize) ->  Self { ix as u16 }
+    fn from(ix: usize) -> Self {
+        ix as u16
+    }
 }
 
 impl Index for u32 {
     #[inline(always)]
-    fn to_usize(self) -> usize { self as usize }
+    fn to_usize(self) -> usize {
+        self as usize
+    }
     #[inline(always)]
-    fn from(ix: usize) ->  Self { ix as u32 }
+    fn from(ix: usize) -> Self {
+        ix as u32
+    }
 }
 
 impl Index for usize {
     #[inline(always)]
-    fn to_usize(self) -> usize { self }
+    fn to_usize(self) -> usize {
+        self
+    }
     #[inline(always)]
-    fn from(ix: usize) ->  Self { ix }
+    fn from(ix: usize) -> Self {
+        ix
+    }
 }
 
 macro_rules! fix_array_impl {
-    ($index_type:ty, $len:expr ) => (
+    ($index_type:ty, $len:expr ) => {
         unsafe impl<T> Array for [T; $len] {
             type Item = T;
             type Index = $index_type;
             const CAPACITY: usize = $len;
             #[doc(hidden)]
-            fn as_slice(&self) -> &[Self::Item] { self }
+            fn as_slice(&self) -> &[Self::Item] {
+                self
+            }
             #[doc(hidden)]
-            fn as_mut_slice(&mut self) -> &mut [Self::Item] { self }
+            fn as_mut_slice(&mut self) -> &mut [Self::Item] {
+                self
+            }
         }
-    )
+    };
 }
 
 macro_rules! fix_array_impl_recursive {
@@ -101,44 +128,40 @@ macro_rules! fix_array_impl_recursive {
     );
 }
 
-
 fix_array_impl_recursive!((), 0,);
 fix_array_impl_recursive!(bool, 1,);
-fix_array_impl_recursive!(u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-                          15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-                          28, 29, 30, 31, );
-
-#[cfg(not(feature="array-sizes-33-128"))]
-fix_array_impl_recursive!(u8, 32, 40, 48, 50, 56, 64, 72, 96, 100, 128, );
-
-#[cfg(feature="array-sizes-33-128")]
-fix_array_impl_recursive!(u8, 
-32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
-92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108,
-109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-125, 126, 127, 128,
+fix_array_impl_recursive!(
+    u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31,
 );
 
-#[cfg(not(feature="array-sizes-129-255"))]
+#[cfg(not(feature = "array-sizes-33-128"))]
+fix_array_impl_recursive!(u8, 32, 40, 48, 50, 56, 64, 72, 96, 100, 128,);
+
+#[cfg(feature = "array-sizes-33-128")]
+fix_array_impl_recursive!(
+    u8, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+    55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78,
+    79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101,
+    102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+    121, 122, 123, 124, 125, 126, 127, 128,
+);
+
+#[cfg(not(feature = "array-sizes-129-255"))]
 fix_array_impl_recursive!(u8, 160, 192, 200, 224,);
 
-#[cfg(feature="array-sizes-129-255")]
-fix_array_impl_recursive!(u8,
-129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
-141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156,
-157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
-189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204,
-205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236,
-237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252,
-253, 254, 255,
+#[cfg(feature = "array-sizes-129-255")]
+fix_array_impl_recursive!(
+    u8, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146,
+    147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
+    166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
+    185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203,
+    204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222,
+    223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255,
 );
 
 fix_array_impl_recursive!(u16, 256, 384, 512, 768, 1024, 2048, 4096, 8192, 16384, 32768,);
 // This array size doesn't exist on 16-bit
-#[cfg(any(target_pointer_width="32", target_pointer_width="64"))]
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 fix_array_impl_recursive!(u32, 1 << 16,);
-

--- a/src/array.rs
+++ b/src/array.rs
@@ -43,9 +43,7 @@ impl Index for () {
         0
     }
     #[inline(always)]
-    fn from(_ix: usize) -> Self {
-        ()
-    }
+    fn from(_ix: usize) -> Self {}
 }
 
 impl Index for bool {

--- a/src/array.rs
+++ b/src/array.rs
@@ -66,7 +66,7 @@ impl Index for u8 {
     }
     #[inline(always)]
     fn from(ix: usize) -> Self {
-        ix as u8
+        ix as Self
     }
 }
 
@@ -77,7 +77,7 @@ impl Index for u16 {
     }
     #[inline(always)]
     fn from(ix: usize) -> Self {
-        ix as u16
+        ix as Self
     }
 }
 
@@ -88,7 +88,7 @@ impl Index for u32 {
     }
     #[inline(always)]
     fn from(ix: usize) -> Self {
-        ix as u32
+        ix as Self
     }
 }
 

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -241,7 +241,7 @@ where
             return Err(CapacityError::new(s));
         }
         unsafe {
-            let dst = self.xs.ptr_mut().offset(self.len() as isize);
+            let dst = self.xs.ptr_mut().add(self.len());
             let src = s.as_ptr();
             ptr::copy_nonoverlapping(src, dst, s.len());
             let newl = self.len() + s.len();
@@ -333,8 +333,8 @@ where
         let len = self.len();
         unsafe {
             ptr::copy(
-                self.xs.ptr().offset(next as isize),
-                self.xs.ptr_mut().offset(idx as isize),
+                self.xs.ptr().add(next),
+                self.xs.ptr_mut().add(idx),
                 len - next,
             );
             self.set_len(len - (next - idx));

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -351,8 +351,12 @@ where
 
     /// Set the strings’s length.
     ///
+    /// # Safety
+    ///
     /// This function is `unsafe` because it changes the notion of the
     /// number of “valid” bytes in the string. Use with care.
+    ///
+    /// # Note
     ///
     /// This method uses *debug assertions* to check the validity of `length`
     /// and may use other debug assertions.

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -2,20 +2,20 @@ use std::borrow::Borrow;
 use std::cmp;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::ptr;
 use std::ops::{Deref, DerefMut};
+use std::ptr;
+use std::slice;
 use std::str;
 use std::str::FromStr;
 use std::str::Utf8Error;
-use std::slice;
 
 use crate::array::Array;
 use crate::array::Index;
-use crate::CapacityError;
 use crate::char::encode_utf8;
+use crate::CapacityError;
 
-#[cfg(feature="serde")]
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::MaybeUninit as MaybeUninitCopy;
 
@@ -28,14 +28,16 @@ use super::MaybeUninit as MaybeUninitCopy;
 /// if needed.
 #[derive(Copy)]
 pub struct ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     xs: MaybeUninitCopy<A>,
     len: A::Index,
 }
 
 impl<A> Default for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     /// Return an empty `ArrayString`
     fn default() -> ArrayString<A> {
@@ -44,7 +46,8 @@ impl<A> Default for ArrayString<A>
 }
 
 impl<A> ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     /// Create a new empty `ArrayString`.
     ///
@@ -69,11 +72,15 @@ impl<A> ArrayString<A>
 
     /// Return the length of the string.
     #[inline]
-    pub fn len(&self) -> usize { self.len.to_usize() }
+    pub fn len(&self) -> usize {
+        self.len.to_usize()
+    }
 
     /// Returns whether the string is empty.
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Create a new `ArrayString` from a `str`.
     ///
@@ -122,7 +129,9 @@ impl<A> ArrayString<A>
     /// assert_eq!(string.capacity(), 3);
     /// ```
     #[inline(always)]
-    pub fn capacity(&self) -> usize { A::CAPACITY }
+    pub fn capacity(&self) -> usize {
+        A::CAPACITY
+    }
 
     /// Return if the `ArrayString` is completely filled.
     ///
@@ -134,7 +143,9 @@ impl<A> ArrayString<A>
     /// string.push_str("A");
     /// assert!(string.is_full());
     /// ```
-    pub fn is_full(&self) -> bool { self.len() == self.capacity() }
+    pub fn is_full(&self) -> bool {
+        self.len() == self.capacity()
+    }
 
     /// Adds the given char to the end of the string.
     ///
@@ -245,7 +256,7 @@ impl<A> ArrayString<A>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<[_; 3]>::from("foo").unwrap();
     ///
     /// assert_eq!(s.pop(), Some('o'));
@@ -285,7 +296,7 @@ impl<A> ArrayString<A>
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
             assert!(self.is_char_boundary(new_len));
-            unsafe { 
+            unsafe {
                 // In libstd truncate is called on the underlying vector,
                 // which in turns drops each element.
                 // As we know we don't have to worry about Drop,
@@ -305,7 +316,7 @@ impl<A> ArrayString<A>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<[_; 3]>::from("foo").unwrap();
     ///
     /// assert_eq!(s.remove(0), 'f');
@@ -321,9 +332,11 @@ impl<A> ArrayString<A>
         let next = idx + ch.len_utf8();
         let len = self.len();
         unsafe {
-            ptr::copy(self.xs.ptr().offset(next as isize),
-                      self.xs.ptr_mut().offset(idx as isize),
-                      len - next);
+            ptr::copy(
+                self.xs.ptr().offset(next as isize),
+                self.xs.ptr_mut().offset(idx as isize),
+                len - next,
+            );
             self.set_len(len - (next - idx));
         }
         ch
@@ -355,7 +368,8 @@ impl<A> ArrayString<A>
 }
 
 impl<A> Deref for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     type Target = str;
     #[inline]
@@ -368,7 +382,8 @@ impl<A> Deref for ArrayString<A>
 }
 
 impl<A> DerefMut for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut str {
@@ -380,7 +395,8 @@ impl<A> DerefMut for ArrayString<A>
 }
 
 impl<A> PartialEq for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn eq(&self, rhs: &Self) -> bool {
         **self == **rhs
@@ -388,7 +404,8 @@ impl<A> PartialEq for ArrayString<A>
 }
 
 impl<A> PartialEq<str> for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn eq(&self, rhs: &str) -> bool {
         &**self == rhs
@@ -396,19 +413,19 @@ impl<A> PartialEq<str> for ArrayString<A>
 }
 
 impl<A> PartialEq<ArrayString<A>> for str
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn eq(&self, rhs: &ArrayString<A>) -> bool {
         self == &**rhs
     }
 }
 
-impl<A> Eq for ArrayString<A> 
-    where A: Array<Item=u8> + Copy
-{ }
+impl<A> Eq for ArrayString<A> where A: Array<Item = u8> + Copy {}
 
 impl<A> Hash for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn hash<H: Hasher>(&self, h: &mut H) {
         (**self).hash(h)
@@ -416,32 +433,45 @@ impl<A> Hash for ArrayString<A>
 }
 
 impl<A> Borrow<str> for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
-    fn borrow(&self) -> &str { self }
+    fn borrow(&self) -> &str {
+        self
+    }
 }
 
 impl<A> AsRef<str> for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
-    fn as_ref(&self) -> &str { self }
+    fn as_ref(&self) -> &str {
+        self
+    }
 }
 
 impl<A> fmt::Debug for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { (**self).fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
 impl<A> fmt::Display for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { (**self).fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
 /// `Write` appends written data to the end of the string.
 impl<A> fmt::Write for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn write_char(&mut self, c: char) -> fmt::Result {
         self.try_push(c).map_err(|_| fmt::Error)
@@ -453,7 +483,8 @@ impl<A> fmt::Write for ArrayString<A>
 }
 
 impl<A> Clone for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn clone(&self) -> ArrayString<A> {
         *self
@@ -466,43 +497,71 @@ impl<A> Clone for ArrayString<A>
 }
 
 impl<A> PartialOrd for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
         (**self).partial_cmp(&**rhs)
     }
-    fn lt(&self, rhs: &Self) -> bool { **self < **rhs }
-    fn le(&self, rhs: &Self) -> bool { **self <= **rhs }
-    fn gt(&self, rhs: &Self) -> bool { **self > **rhs }
-    fn ge(&self, rhs: &Self) -> bool { **self >= **rhs }
+    fn lt(&self, rhs: &Self) -> bool {
+        **self < **rhs
+    }
+    fn le(&self, rhs: &Self) -> bool {
+        **self <= **rhs
+    }
+    fn gt(&self, rhs: &Self) -> bool {
+        **self > **rhs
+    }
+    fn ge(&self, rhs: &Self) -> bool {
+        **self >= **rhs
+    }
 }
 
 impl<A> PartialOrd<str> for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn partial_cmp(&self, rhs: &str) -> Option<cmp::Ordering> {
         (**self).partial_cmp(rhs)
     }
-    fn lt(&self, rhs: &str) -> bool { &**self < rhs }
-    fn le(&self, rhs: &str) -> bool { &**self <= rhs }
-    fn gt(&self, rhs: &str) -> bool { &**self > rhs }
-    fn ge(&self, rhs: &str) -> bool { &**self >= rhs }
+    fn lt(&self, rhs: &str) -> bool {
+        &**self < rhs
+    }
+    fn le(&self, rhs: &str) -> bool {
+        &**self <= rhs
+    }
+    fn gt(&self, rhs: &str) -> bool {
+        &**self > rhs
+    }
+    fn ge(&self, rhs: &str) -> bool {
+        &**self >= rhs
+    }
 }
 
 impl<A> PartialOrd<ArrayString<A>> for str
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn partial_cmp(&self, rhs: &ArrayString<A>) -> Option<cmp::Ordering> {
         self.partial_cmp(&**rhs)
     }
-    fn lt(&self, rhs: &ArrayString<A>) -> bool { self < &**rhs }
-    fn le(&self, rhs: &ArrayString<A>) -> bool { self <= &**rhs }
-    fn gt(&self, rhs: &ArrayString<A>) -> bool { self > &**rhs }
-    fn ge(&self, rhs: &ArrayString<A>) -> bool { self >= &**rhs }
+    fn lt(&self, rhs: &ArrayString<A>) -> bool {
+        self < &**rhs
+    }
+    fn le(&self, rhs: &ArrayString<A>) -> bool {
+        self <= &**rhs
+    }
+    fn gt(&self, rhs: &ArrayString<A>) -> bool {
+        self > &**rhs
+    }
+    fn ge(&self, rhs: &ArrayString<A>) -> bool {
+        self >= &**rhs
+    }
 }
 
 impl<A> Ord for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn cmp(&self, rhs: &Self) -> cmp::Ordering {
         (**self).cmp(&**rhs)
@@ -510,7 +569,8 @@ impl<A> Ord for ArrayString<A>
 }
 
 impl<A> FromStr for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     type Err = CapacityError;
 
@@ -519,48 +579,59 @@ impl<A> FromStr for ArrayString<A>
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
 impl<A> Serialize for ArrayString<A>
-    where A: Array<Item=u8> + Copy
+where
+    A: Array<Item = u8> + Copy,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&*self)
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
-impl<'de, A> Deserialize<'de> for ArrayString<A> 
-    where A: Array<Item=u8> + Copy
+impl<'de, A> Deserialize<'de> for ArrayString<A>
+where
+    A: Array<Item = u8> + Copy,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         use serde::de::{self, Visitor};
         use std::marker::PhantomData;
 
-        struct ArrayStringVisitor<A: Array<Item=u8>>(PhantomData<A>);
+        struct ArrayStringVisitor<A: Array<Item = u8>>(PhantomData<A>);
 
-        impl<'de, A: Copy + Array<Item=u8>> Visitor<'de> for ArrayStringVisitor<A> {
+        impl<'de, A: Copy + Array<Item = u8>> Visitor<'de> for ArrayStringVisitor<A> {
             type Value = ArrayString<A>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "a string no more than {} bytes long", A::CAPACITY)
+                write!(
+                    formatter,
+                    "a string no more than {} bytes long",
+                    A::CAPACITY
+                )
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where E: de::Error,
+            where
+                E: de::Error,
             {
                 ArrayString::from(v).map_err(|_| E::invalid_length(v.len(), &self))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where E: de::Error,
+            where
+                E: de::Error,
             {
-                let s = str::from_utf8(v).map_err(|_| E::invalid_value(de::Unexpected::Bytes(v), &self))?;
+                let s = str::from_utf8(v)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Bytes(v), &self))?;
 
                 ArrayString::from(s).map_err(|_| E::invalid_length(s.len(), &self))
             }

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -40,8 +40,8 @@ where
     A: Array<Item = u8> + Copy,
 {
     /// Return an empty `ArrayString`
-    fn default() -> ArrayString<A> {
-        ArrayString::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -61,9 +61,9 @@ where
     /// assert_eq!(&string[..], "foo");
     /// assert_eq!(string.capacity(), 16);
     /// ```
-    pub fn new() -> ArrayString<A> {
+    pub fn new() -> Self {
         unsafe {
-            ArrayString {
+            Self {
                 xs: MaybeUninitCopy::uninitialized(),
                 len: Index::from(0),
             }
@@ -114,7 +114,7 @@ where
     pub fn from_byte_string(b: &A) -> Result<Self, Utf8Error> {
         let len = str::from_utf8(b.as_slice())?.len();
         debug_assert_eq!(len, A::CAPACITY);
-        Ok(ArrayString {
+        Ok(Self {
             xs: MaybeUninitCopy::from(*b),
             len: Index::from(A::CAPACITY),
         })
@@ -486,7 +486,7 @@ impl<A> Clone for ArrayString<A>
 where
     A: Array<Item = u8> + Copy,
 {
-    fn clone(&self) -> ArrayString<A> {
+    fn clone(&self) -> Self {
         *self
     }
     fn clone_from(&mut self, rhs: &Self) {

--- a/src/char.rs
+++ b/src/char.rs
@@ -13,13 +13,13 @@
 use std::ptr;
 
 // UTF-8 ranges and tags for encoding characters
-const TAG_CONT: u8    = 0b1000_0000;
-const TAG_TWO_B: u8   = 0b1100_0000;
+const TAG_CONT: u8 = 0b1000_0000;
+const TAG_TWO_B: u8 = 0b1100_0000;
 const TAG_THREE_B: u8 = 0b1110_0000;
-const TAG_FOUR_B: u8  = 0b1111_0000;
-const MAX_ONE_B: u32   =     0x80;
-const MAX_TWO_B: u32   =    0x800;
-const MAX_THREE_B: u32 =  0x10000;
+const TAG_FOUR_B: u8 = 0b1111_0000;
+const MAX_ONE_B: u32 = 0x80;
+const MAX_TWO_B: u32 = 0x800;
+const MAX_THREE_B: u32 = 0x10000;
 
 /// Placeholder
 pub struct EncodeUtf8Error;
@@ -36,8 +36,7 @@ unsafe fn write(ptr: *mut u8, index: usize, byte: u8) {
 ///
 /// Safety: `ptr` must be writable for `len` bytes.
 #[inline]
-pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, EncodeUtf8Error>
-{
+pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, EncodeUtf8Error> {
     let code = ch as u32;
     if code < MAX_ONE_B && len >= 1 {
         write(ptr, 0, code as u8);
@@ -48,19 +47,18 @@ pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, E
         return Ok(2);
     } else if code < MAX_THREE_B && len >= 3 {
         write(ptr, 0, (code >> 12 & 0x0F) as u8 | TAG_THREE_B);
-        write(ptr, 1, (code >>  6 & 0x3F) as u8 | TAG_CONT);
+        write(ptr, 1, (code >> 6 & 0x3F) as u8 | TAG_CONT);
         write(ptr, 2, (code & 0x3F) as u8 | TAG_CONT);
         return Ok(3);
     } else if len >= 4 {
         write(ptr, 0, (code >> 18 & 0x07) as u8 | TAG_FOUR_B);
         write(ptr, 1, (code >> 12 & 0x3F) as u8 | TAG_CONT);
-        write(ptr, 2, (code >>  6 & 0x3F) as u8 | TAG_CONT);
+        write(ptr, 2, (code >> 6 & 0x3F) as u8 | TAG_CONT);
         write(ptr, 3, (code & 0x3F) as u8 | TAG_CONT);
         return Ok(4);
     };
     Err(EncodeUtf8Error)
 }
-
 
 #[test]
 #[cfg(not(miri))] // Miri is too slow
@@ -69,7 +67,9 @@ fn test_encode_utf8() {
     let mut data = [0u8; 16];
     for codepoint in 0..=(std::char::MAX as u32) {
         if let Some(ch) = std::char::from_u32(codepoint) {
-            for elt in &mut data { *elt = 0; }
+            for elt in &mut data {
+                *elt = 0;
+            }
             let ptr = data.as_mut_ptr();
             let len = data.len();
             unsafe {
@@ -96,4 +96,3 @@ fn test_encode_utf8_oob() {
         }
     }
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,8 +12,8 @@ pub struct CapacityError<T = ()> {
 
 impl<T> CapacityError<T> {
     /// Create a new `CapacityError` from `element`.
-    pub fn new(element: T) -> CapacityError<T> {
-        CapacityError { element: element }
+    pub fn new(element: T) -> Self {
+        Self { element }
     }
 
     /// Extract the overflowing element

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
-use std::fmt;
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::any::Any;
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::error::Error;
+use std::fmt;
 
 /// Error value indicating insufficient capacity
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
@@ -13,9 +13,7 @@ pub struct CapacityError<T = ()> {
 impl<T> CapacityError<T> {
     /// Create a new `CapacityError` from `element`.
     pub fn new(element: T) -> CapacityError<T> {
-        CapacityError {
-            element: element,
-        }
+        CapacityError { element: element }
     }
 
     /// Extract the overflowing element
@@ -31,7 +29,7 @@ impl<T> CapacityError<T> {
 
 const CAPERROR: &'static str = "insufficient capacity";
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 /// Requires `features="std"`.
 impl<T: Any> Error for CapacityError<T> {
     fn description(&self) -> &str {
@@ -50,4 +48,3 @@ impl<T> fmt::Debug for CapacityError<T> {
         write!(f, "{}: {}", "CapacityError", CAPERROR)
     }
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,7 +27,7 @@ impl<T> CapacityError<T> {
     }
 }
 
-const CAPERROR: &'static str = "insufficient capacity";
+const CAPERROR: &str = "insufficient capacity";
 
 #[cfg(feature = "std")]
 /// Requires `features="std"`.
@@ -45,6 +45,6 @@ impl<T> fmt::Display for CapacityError<T> {
 
 impl<T> fmt::Debug for CapacityError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", "CapacityError", CAPERROR)
+        write!(f, "CapacityError: {}", CAPERROR)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(&array[..], &[1, 2]);
     /// assert_eq!(array.capacity(), 16);
     /// ```
-    pub fn new() -> ArrayVec<A> {
+    pub fn new() -> Self {
         unsafe {
-            ArrayVec {
+            Self {
                 xs: MaybeUninit::uninitialized(),
                 len: Index::from(0),
             }
@@ -716,7 +716,7 @@ impl<A: Array> DerefMut for ArrayVec<A> {
 /// ```
 impl<A: Array> From<A> for ArrayVec<A> {
     fn from(array: A) -> Self {
-        ArrayVec {
+        Self {
             xs: MaybeUninit::from(array),
             len: Index::from(A::CAPACITY),
         }
@@ -843,7 +843,7 @@ impl<A: Array> Clone for IntoIter<A>
 where
     A::Item: Clone,
 {
-    fn clone(&self) -> IntoIter<A> {
+    fn clone(&self) -> Self {
         self.v[self.index.to_usize()..]
             .iter()
             .cloned()
@@ -1017,7 +1017,7 @@ unsafe fn raw_ptr_write<T>(ptr: *mut T, value: T) {
 /// occurs if there are more iterator elements.
 impl<A: Array> iter::FromIterator<A::Item> for ArrayVec<A> {
     fn from_iter<T: IntoIterator<Item = A::Item>>(iter: T) -> Self {
-        let mut array = ArrayVec::new();
+        let mut array = Self::new();
         array.extend(iter);
         array
     }
@@ -1112,8 +1112,8 @@ where
 
 impl<A: Array> Default for ArrayVec<A> {
     /// Return an empty array
-    fn default() -> ArrayVec<A> {
-        ArrayVec::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1121,7 +1121,7 @@ impl<A: Array> PartialOrd for ArrayVec<A>
 where
     A::Item: PartialOrd,
 {
-    fn partial_cmp(&self, other: &ArrayVec<A>) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         (**self).partial_cmp(other)
     }
 
@@ -1146,7 +1146,7 @@ impl<A: Array> Ord for ArrayVec<A>
 where
     A::Item: Ord,
 {
-    fn cmp(&self, other: &ArrayVec<A>) -> cmp::Ordering {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         (**self).cmp(other)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **arrayvec** provides the types `ArrayVec` and `ArrayString`:
+//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]:
 //! array-backed vector and string types, which store their contents inline.
 //!
 //! The arrayvec package has the following cargo features:
@@ -69,7 +69,7 @@ pub use crate::errors::CapacityError;
 /// It offers a simple API but also dereferences to a slice, so
 /// that the full slice API is available.
 ///
-/// ArrayVec can be converted into a by value iterator.
+/// `ArrayVec` can be converted into a by value iterator.
 pub struct ArrayVec<A: Array> {
     xs: MaybeUninit<A>,
     len: A::Index,
@@ -101,12 +101,16 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// Capacity is inferred from the type parameter.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 16]>::new();
+    ///
     /// array.push(1);
     /// array.push(2);
+    ///
     /// assert_eq!(&array[..], &[1, 2]);
     /// assert_eq!(array.capacity(), 16);
     /// ```
@@ -121,10 +125,13 @@ impl<A: Array> ArrayVec<A> {
 
     /// Return the number of elements in the `ArrayVec`.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
+    ///
     /// array.pop();
     /// assert_eq!(array.len(), 2);
     /// ```
@@ -135,10 +142,13 @@ impl<A: Array> ArrayVec<A> {
 
     /// Returns whether the `ArrayVec` is empty.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1]);
+    ///
     /// array.pop();
     /// assert_eq!(array.is_empty(), true);
     /// ```
@@ -149,10 +159,13 @@ impl<A: Array> ArrayVec<A> {
 
     /// Return the capacity of the `ArrayVec`.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let array = ArrayVec::from([1, 2, 3]);
+    ///
     /// assert_eq!(array.capacity(), 3);
     /// ```
     #[inline(always)]
@@ -162,13 +175,16 @@ impl<A: Array> ArrayVec<A> {
 
     /// Return if the `ArrayVec` is completely filled.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 1]>::new();
-    /// assert!(!array.is_full());
+    ///
+    /// assert_eq!(array.is_full(), false);
     /// array.push(1);
-    /// assert!(array.is_full());
+    /// assert_eq!(array.is_full(), true);
     /// ```
     pub fn is_full(&self) -> bool {
         self.len() == self.capacity()
@@ -176,10 +192,13 @@ impl<A: Array> ArrayVec<A> {
 
     /// Returns the capacity left in the `ArrayVec`.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
+    ///
     /// array.pop();
     /// assert_eq!(array.remaining_capacity(), 1);
     /// ```
@@ -187,13 +206,17 @@ impl<A: Array> ArrayVec<A> {
         self.capacity() - self.len()
     }
 
-    /// Push `element` to the end of the vector.
+    /// Push an `element` to the end of the vector.
     ///
-    /// ***Panics*** if the vector is already full.
+    /// # Panics
+    ///
+    /// Panics if the vector is already full.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 2]>::new();
     ///
     /// array.push(1);
@@ -205,27 +228,36 @@ impl<A: Array> ArrayVec<A> {
         self.try_push(element).unwrap()
     }
 
-    /// Push `element` to the end of the vector.
+    /// Push an `element` to the end of the vector.
     ///
-    /// Return `Ok` if the push succeeds, or return an error if the vector
-    /// is already full.
+    /// # Errors
+    ///
+    /// Returns an error if the vector is already full.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 2]>::new();
     ///
-    /// let push1 = array.try_push(1);
-    /// let push2 = array.try_push(2);
-    ///
-    /// assert!(push1.is_ok());
-    /// assert!(push2.is_ok());
+    /// array.try_push(1)?;
+    /// array.try_push(2)?;
     ///
     /// assert_eq!(&array[..], &[1, 2]);
+    /// # Ok::<(), arrayvec::CapacityError<usize>>(())
+    /// ```
     ///
-    /// let overflow = array.try_push(3);
+    /// Overflowing the array
     ///
-    /// assert!(overflow.is_err());
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
+    /// let mut array = ArrayVec::<[_; 1]>::new();
+    ///
+    /// array.try_push(1)?;
+    /// assert!(array.try_push(2).is_err());
+    /// # Ok::<(), arrayvec::CapacityError<usize>>(())
     /// ```
     pub fn try_push(&mut self, element: A::Item) -> Result<(), CapacityError<A::Item>> {
         if self.len() < A::CAPACITY {
@@ -238,16 +270,22 @@ impl<A: Array> ArrayVec<A> {
         }
     }
 
-    /// Push `element` to the end of the vector without checking the capacity.
+    /// Push an `element` to the end of the vector without checking the capacity.
+    ///
+    /// # Safety
     ///
     /// It is up to the caller to ensure the capacity of the vector is
     /// sufficiently large.
     ///
-    /// This method uses *debug assertions* to check that the arrayvec is not full.
+    /// # Note
+    ///
+    /// This method uses [`debug_assert`] to check that the arrayvec is not full.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 2]>::new();
     ///
     /// if array.len() + 2 <= array.capacity() {
@@ -271,15 +309,16 @@ impl<A: Array> ArrayVec<A> {
         self.xs.ptr_mut().add(index)
     }
 
-    /// Insert `element` at position `index`.
+    /// Insert `element` at position `index` and shift up all elements after it.
     ///
-    /// Shift up all elements after `index`.
+    /// # Panics
     ///
-    /// It is an error if the index is greater than the length or if the
-    /// arrayvec is full.
+    /// Panics if the array is full or the `index` is out of bounds.
     ///
-    /// ***Panics*** if the array is full or the `index` is out of bounds. See
-    /// `try_insert` for fallible version.
+    /// # Note
+    /// See [`try_insert`] for a fallible version.
+    ///
+    /// # Example
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -289,31 +328,40 @@ impl<A: Array> ArrayVec<A> {
     /// array.insert(0, "x");
     /// array.insert(0, "y");
     /// assert_eq!(&array[..], &["y", "x"]);
-    ///
     /// ```
+    ///
+    /// [`try_insert`]: #method.try_insert
     pub fn insert(&mut self, index: usize, element: A::Item) {
         self.try_insert(index, element).unwrap()
     }
 
-    /// Insert `element` at position `index`.
+    /// Insert `element` at position `index` and shift up all elements after it.
     ///
-    /// Shift up all elements after `index`; the `index` must be less than
-    /// or equal to the length.
+    /// The `index` must be less than or equal to the length.
+    ///
+    /// # Errors
     ///
     /// Returns an error if vector is already at full capacity.
     ///
-    /// ***Panics*** `index` is out of bounds.
+    /// # Panics
+    ///
+    /// Panics if the `index` is out of bounds.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::<[_; 2]>::new();
     ///
-    /// assert!(array.try_insert(0, "x").is_ok());
-    /// assert!(array.try_insert(0, "y").is_ok());
-    /// assert!(array.try_insert(0, "z").is_err());
+    /// array.try_insert(0, "x")?;
+    /// array.try_insert(0, "y")?;
+    ///
     /// assert_eq!(&array[..], &["y", "x"]);
     ///
+    /// assert!(array.try_insert(0, "z").is_err());
+    /// #
+    /// # Ok::<(), arrayvec::CapacityError<&str>>(())
     /// ```
     pub fn try_insert(
         &mut self,
@@ -346,9 +394,13 @@ impl<A: Array> ArrayVec<A> {
         Ok(())
     }
 
-    /// Remove the last element in the vector and return it.
+    /// Removes the last element in the vector and return it.
     ///
-    /// Return `Some(` *element* `)` if the vector is non-empty, else `None`.
+    /// # Note
+    ///
+    /// This returns `None` if the vector is empty.
+    ///
+    /// # Example
     ///
     /// ```
     /// use arrayvec::ArrayVec;
@@ -375,13 +427,15 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// This operation is O(1).
     ///
-    /// Return the *element* if the index is in bounds, else panic.
+    /// # Panics
     ///
-    /// ***Panics*** if the `index` is out of bounds.
+    /// Panics if the `index` is out of bounds.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
     /// assert_eq!(array.swap_remove(0), 1);
@@ -397,14 +451,18 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and swap the last element into its place.
     ///
-    /// This is a checked version of `.swap_remove`.
+    /// This is a checked version of [`swap_remove`].
     /// This operation is O(1).
     ///
-    /// Return `Some(` *element* `)` if the index is in bounds, else `None`.
+    /// # Note
+    ///
+    /// This function returns `None`, if the index is out of bounds.
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
     /// assert_eq!(array.swap_pop(0), Some(1));
@@ -412,6 +470,8 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// assert_eq!(array.swap_pop(10), None);
     /// ```
+    ///
+    /// [`swap_remove`]: #method.swap_remove
     pub fn swap_pop(&mut self, index: usize) -> Option<A::Item> {
         let len = self.len();
         if index >= len {
@@ -421,19 +481,25 @@ impl<A: Array> ArrayVec<A> {
         self.pop()
     }
 
-    /// Remove the element at `index` and shift down the following elements.
+    /// Removes the element at `index` and shift down the following elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `index` is out of bounds.
+    ///
+    /// # Note
     ///
     /// The `index` must be strictly less than the length of the vector.
     ///
-    /// ***Panics*** if the `index` is out of bounds.
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
-    /// let removed_elt = array.remove(0);
-    /// assert_eq!(removed_elt, 1);
+    /// let removed_element = array.remove(0);
+    /// assert_eq!(removed_element, 1);
     /// assert_eq!(&array[..], &[2, 3]);
     /// ```
     pub fn remove(&mut self, index: usize) -> A::Item {
@@ -443,20 +509,26 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and shift down the following elements.
     ///
-    /// This is a checked version of `.remove(index)`. Returns `None` if there
-    /// is no element at `index`. Otherwise, return the element inside `Some`.
+    /// # Note
+    ///
+    /// Returns `None` if there is no element at `index`.
+    /// This is a checked version of [`remove`].
+    ///
+    /// # Example
     ///
     /// ```
-    /// use arrayvec::ArrayVec;
-    ///
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3]);
     ///
-    /// assert!(array.pop_at(0).is_some());
+    /// assert_eq!(array.pop_at(0), Some(1));
     /// assert_eq!(&array[..], &[2, 3]);
     ///
     /// assert!(array.pop_at(2).is_none());
     /// assert!(array.pop_at(10).is_none());
     /// ```
+    ///
+    /// [`remove`]: #method.remove
     pub fn pop_at(&mut self, index: usize) -> Option<A::Item> {
         if index >= self.len() {
             None
@@ -468,12 +540,16 @@ impl<A: Array> ArrayVec<A> {
     /// Shortens the vector, keeping the first `len` elements and dropping
     /// the rest.
     ///
+    /// # Note
+    ///
     /// If `len` is greater than the vector’s current length this has no
     /// effect.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3, 4, 5]);
     /// array.truncate(3);
     /// assert_eq!(&array[..], &[1, 2, 3]);
@@ -491,20 +567,37 @@ impl<A: Array> ArrayVec<A> {
     }
 
     /// Remove all elements in the vector.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
+    /// let mut array = ArrayVec::from([1, 2, 3, 4]);
+    /// array.clear();
+    ///
+    /// assert!(array.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.truncate(0)
     }
 
     /// Retains only the elements specified by the predicate.
     ///
-    /// In other words, remove all elements `e` such that `f(&mut e)` returns false.
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    ///
+    /// # Note
+    ///
     /// This method operates in place and preserves the order of the retained
     /// elements.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut array = ArrayVec::from([1, 2, 3, 4]);
+    ///
     /// array.retain(|x| *x & 1 != 0 );
     /// assert_eq!(&array[..], &[1, 3]);
     /// ```
@@ -532,10 +625,14 @@ impl<A: Array> ArrayVec<A> {
 
     /// Set the vector’s length without dropping or moving out elements
     ///
+    /// # Safety
+    ///
     /// This method is `unsafe` because it changes the notion of the
     /// number of “valid” elements in the vector. Use with care.
     ///
-    /// This method uses *debug assertions* to check that `length` is
+    /// # Note
+    ///
+    /// This method uses [`debug_assert`] to check that `length` is
     /// not greater than the capacity.
     pub unsafe fn set_len(&mut self, length: usize) {
         debug_assert!(length <= self.capacity());
@@ -544,20 +641,22 @@ impl<A: Array> ArrayVec<A> {
 
     /// Copy and appends all elements in a slice to the `ArrayVec`.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Errors
     ///
+    /// This method returns an error if the remaining capacity (see
+    /// [`remaining_capacity`]) is smaller then the length of the provided
+    /// slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut vec: ArrayVec<[usize; 10]> = ArrayVec::new();
     /// vec.push(1);
     /// vec.try_extend_from_slice(&[2, 3]).unwrap();
     /// assert_eq!(&vec[..], &[1, 2, 3]);
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// This method will return an error if the capacity left (see
-    /// [`remaining_capacity`]) is smaller then the length of the provided
-    /// slice.
     ///
     /// [`remaining_capacity`]: #method.remaining_capacity
     pub fn try_extend_from_slice(&mut self, other: &[A::Item]) -> Result<(), CapacityError>
@@ -583,15 +682,21 @@ impl<A: Array> ArrayVec<A> {
     /// and yields the removed items from start to end. The element range is
     /// removed even if the iterator is not consumed until the end.
     ///
-    /// Note: It is unspecified how many elements are removed from the vector,
+    /// # Note
+    ///
+    /// It is unspecified how many elements are removed from the vector,
     /// if the `Drain` value is leaked.
     ///
-    /// **Panics** if the starting point is greater than the end point or if
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if
     /// the end point is greater than the length of the vector.
     ///
-    /// ```
-    /// use arrayvec::ArrayVec;
+    /// # Example
     ///
+    /// ```
+    /// # use arrayvec::ArrayVec;
+    /// #
     /// let mut v = ArrayVec::from([1, 2, 3]);
     /// let u: ArrayVec<[_; 3]> = v.drain(0..2).collect();
     /// assert_eq!(&v[..], &[3]);
@@ -647,8 +752,10 @@ impl<A: Array> ArrayVec<A> {
 
     /// Return the inner fixed size array, if it is full to its capacity.
     ///
-    /// Return an `Ok` value with the array if length equals capacity,
-    /// return an `Err` with self otherwise.
+    /// # Error
+    ///
+    /// This returns the array if the length equals the capacity,
+    /// otherwise an error is returned with `self`.
     pub fn into_inner(self) -> Result<A, Self> {
         if self.len() < self.capacity() {
             Err(self)
@@ -705,12 +812,15 @@ impl<A: Array> DerefMut for ArrayVec<A> {
     }
 }
 
-/// Create an `ArrayVec` from an array.
+/// Create an [`ArrayVec`] from a type implementing [`Array`].
+///
+/// # Example
 ///
 /// ```
-/// use arrayvec::ArrayVec;
-///
+/// # use arrayvec::ArrayVec;
+/// #
 /// let mut array = ArrayVec::from([1, 2, 3]);
+///
 /// assert_eq!(array.len(), 3);
 /// assert_eq!(array.capacity(), 3);
 /// ```
@@ -723,14 +833,16 @@ impl<A: Array> From<A> for ArrayVec<A> {
     }
 }
 
-/// Iterate the `ArrayVec` with references to each element.
+/// Iterate the [`ArrayVec`] with references to each element.
+///
+/// # Example
 ///
 /// ```
-/// use arrayvec::ArrayVec;
-///
+/// # use arrayvec::ArrayVec;
+/// #
 /// let array = ArrayVec::from([1, 2, 3]);
 ///
-/// for elt in &array {
+/// for element in &array {
 ///     // ...
 /// }
 /// ```
@@ -742,14 +854,16 @@ impl<'a, A: Array> IntoIterator for &'a ArrayVec<A> {
     }
 }
 
-/// Iterate the `ArrayVec` with mutable references to each element.
+/// Iterate the [`ArrayVec`] with mutable references to each element.
+///
+/// # Example
 ///
 /// ```
-/// use arrayvec::ArrayVec;
-///
+/// # use arrayvec::ArrayVec;
+/// #
 /// let mut array = ArrayVec::from([1, 2, 3]);
 ///
-/// for elt in &mut array {
+/// for element in &mut array {
 ///     // ...
 /// }
 /// ```
@@ -761,14 +875,16 @@ impl<'a, A: Array> IntoIterator for &'a mut ArrayVec<A> {
     }
 }
 
-/// Iterate the `ArrayVec` with each element by value.
+/// Iterate the [`ArrayVec`] with each element by value.
 ///
 /// The vector is consumed by this operation.
 ///
-/// ```
-/// use arrayvec::ArrayVec;
+/// # Example
 ///
-/// for elt in ArrayVec::from([1, 2, 3]) {
+/// ```
+/// # use arrayvec::ArrayVec;
+/// #
+/// for element in ArrayVec::from([1, 2, 3]) {
 ///     // ...
 /// }
 /// ```
@@ -783,7 +899,7 @@ impl<A: Array> IntoIterator for ArrayVec<A> {
     }
 }
 
-/// By-value iterator for `ArrayVec`.
+/// By-value iterator for [`ArrayVec`].
 pub struct IntoIter<A: Array> {
     index: A::Index,
     v: ArrayVec<A>,
@@ -863,7 +979,7 @@ where
     }
 }
 
-/// A draining iterator for `ArrayVec`.
+/// A draining iterator for [`ArrayVec`].
 pub struct Drain<'a, A>
 where
     A: Array,
@@ -954,7 +1070,9 @@ where
     }
 }
 
-/// Extend the `ArrayVec` with an iterator.
+/// Extend the [`ArrayVec`] with an iterator.
+///
+/// # Note
 ///
 /// Does not extract more items than there is space for. No error
 /// occurs if there are more iterator elements.
@@ -1011,7 +1129,9 @@ unsafe fn raw_ptr_write<T>(ptr: *mut T, value: T) {
     }
 }
 
-/// Create an `ArrayVec` from an iterator.
+/// Create an [`ArrayVec`] from an iterator.
+///
+/// # Note
 ///
 /// Does not extract more items than there is space for. No error
 /// occurs if there are more iterator elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **arrayvec** provides the types `ArrayVec` and `ArrayString`: 
+//! **arrayvec** provides the types `ArrayVec` and `ArrayString`:
 //! array-backed vector and string types, which store their contents inline.
 //!
 //! The arrayvec package has the following cargo features:
@@ -18,13 +18,13 @@
 //!
 //! This version of arrayvec requires Rust 1.36 or later.
 //!
-#![doc(html_root_url="https://docs.rs/arrayvec/0.4/")]
-#![cfg_attr(not(feature="std"), no_std)]
+#![doc(html_root_url = "https://docs.rs/arrayvec/0.4/")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 extern crate core as std;
 
 use std::cmp;
@@ -36,18 +36,17 @@ use std::slice;
 
 // extra traits
 use std::borrow::{Borrow, BorrowMut};
-use std::hash::{Hash, Hasher};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::io;
-
 
 mod maybe_uninit;
 use crate::maybe_uninit::MaybeUninit;
 
-#[cfg(feature="serde")]
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 mod array;
 mod array_string;
@@ -58,7 +57,6 @@ pub use crate::array::Array;
 use crate::array::Index;
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
-
 
 /// A vector with a fixed capacity.
 ///
@@ -87,9 +85,15 @@ impl<A: Array> Drop for ArrayVec<A> {
 
 macro_rules! panic_oob {
     ($method_name:expr, $index:expr, $len:expr) => {
-        panic!(concat!("ArrayVec::", $method_name, ": index {} is out of bounds in vector of length {}"),
-               $index, $len)
-    }
+        panic!(
+            concat!(
+                "ArrayVec::",
+                $method_name,
+                ": index {} is out of bounds in vector of length {}"
+            ),
+            $index, $len
+        )
+    };
 }
 
 impl<A: Array> ArrayVec<A> {
@@ -108,7 +112,10 @@ impl<A: Array> ArrayVec<A> {
     /// ```
     pub fn new() -> ArrayVec<A> {
         unsafe {
-            ArrayVec { xs: MaybeUninit::uninitialized(), len: Index::from(0) }
+            ArrayVec {
+                xs: MaybeUninit::uninitialized(),
+                len: Index::from(0),
+            }
         }
     }
 
@@ -122,7 +129,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(array.len(), 2);
     /// ```
     #[inline]
-    pub fn len(&self) -> usize { self.len.to_usize() }
+    pub fn len(&self) -> usize {
+        self.len.to_usize()
+    }
 
     /// Returns whether the `ArrayVec` is empty.
     ///
@@ -134,7 +143,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(array.is_empty(), true);
     /// ```
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Return the capacity of the `ArrayVec`.
     ///
@@ -145,7 +156,9 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(array.capacity(), 3);
     /// ```
     #[inline(always)]
-    pub fn capacity(&self) -> usize { A::CAPACITY }
+    pub fn capacity(&self) -> usize {
+        A::CAPACITY
+    }
 
     /// Return if the `ArrayVec` is completely filled.
     ///
@@ -157,7 +170,9 @@ impl<A: Array> ArrayVec<A> {
     /// array.push(1);
     /// assert!(array.is_full());
     /// ```
-    pub fn is_full(&self) -> bool { self.len() == self.capacity() }
+    pub fn is_full(&self) -> bool {
+        self.len() == self.capacity()
+    }
 
     /// Returns the capacity left in the `ArrayVec`.
     ///
@@ -222,7 +237,6 @@ impl<A: Array> ArrayVec<A> {
             Err(CapacityError::new(element))
         }
     }
-
 
     /// Push `element` to the end of the vector without checking the capacity.
     ///
@@ -301,7 +315,11 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(&array[..], &["y", "x"]);
     ///
     /// ```
-    pub fn try_insert(&mut self, index: usize, element: A::Item) -> Result<(), CapacityError<A::Item>> {
+    pub fn try_insert(
+        &mut self,
+        index: usize,
+        element: A::Item,
+    ) -> Result<(), CapacityError<A::Item>> {
         if index > self.len() {
             panic_oob!("try_insert", index, self.len())
         }
@@ -311,7 +329,8 @@ impl<A: Array> ArrayVec<A> {
         let len = self.len();
 
         // follows is just like Vec<T>
-        unsafe { // infallible
+        unsafe {
+            // infallible
             // The spot to put the new value
             {
                 let p: *mut _ = self.get_unchecked_ptr(index);
@@ -373,9 +392,7 @@ impl<A: Array> ArrayVec<A> {
     /// ```
     pub fn swap_remove(&mut self, index: usize) -> A::Item {
         self.swap_pop(index)
-            .unwrap_or_else(|| {
-                panic_oob!("swap_remove", index, self.len())
-            })
+            .unwrap_or_else(|| panic_oob!("swap_remove", index, self.len()))
     }
 
     /// Remove the element at `index` and swap the last element into its place.
@@ -421,9 +438,7 @@ impl<A: Array> ArrayVec<A> {
     /// ```
     pub fn remove(&mut self, index: usize) -> A::Item {
         self.pop_at(index)
-            .unwrap_or_else(|| {
-                panic_oob!("remove", index, self.len())
-            })
+            .unwrap_or_else(|| panic_oob!("remove", index, self.len()))
     }
 
     /// Remove the element at `index` and shift down the following elements.
@@ -494,7 +509,8 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(&array[..], &[1, 3]);
     /// ```
     pub fn retain<F>(&mut self, mut f: F)
-        where F: FnMut(&mut A::Item) -> bool
+    where
+        F: FnMut(&mut A::Item) -> bool,
     {
         let len = self.len();
         let mut del = 0;
@@ -545,7 +561,8 @@ impl<A: Array> ArrayVec<A> {
     ///
     /// [`remaining_capacity`]: #method.remaining_capacity
     pub fn try_extend_from_slice(&mut self, other: &[A::Item]) -> Result<(), CapacityError>
-        where A::Item: Copy,
+    where
+        A::Item: Copy,
     {
         if self.remaining_capacity() < other.len() {
             return Err(CapacityError::new(()));
@@ -581,7 +598,8 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(&u[..], &[1, 2]);
     /// ```
     pub fn drain<R>(&mut self, range: R) -> Drain<A>
-        where R: RangeBounds<usize>
+    where
+        R: RangeBounds<usize>,
     {
         // Memory safety
         //
@@ -607,8 +625,7 @@ impl<A: Array> ArrayVec<A> {
         self.drain_range(start, end)
     }
 
-    fn drain_range(&mut self, start: usize, end: usize) -> Drain<A>
-    {
+    fn drain_range(&mut self, start: usize, end: usize) -> Drain<A> {
         let len = self.len();
 
         // bounds check happens here (before length is changed!)
@@ -645,7 +662,7 @@ impl<A: Array> ArrayVec<A> {
     }
 
     /// Dispose of `self` (same as drop)
-    #[deprecated="Use std::mem::drop instead, if at all needed."]
+    #[deprecated = "Use std::mem::drop instead, if at all needed."]
     pub fn dispose(mut self) {
         self.clear();
         mem::forget(self);
@@ -676,9 +693,7 @@ impl<A: Array> Deref for ArrayVec<A> {
     type Target = [A::Item];
     #[inline]
     fn deref(&self) -> &[A::Item] {
-        unsafe {
-            slice::from_raw_parts(self.xs.ptr(), self.len())
-        }
+        unsafe { slice::from_raw_parts(self.xs.ptr(), self.len()) }
     }
 }
 
@@ -686,9 +701,7 @@ impl<A: Array> DerefMut for ArrayVec<A> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [A::Item] {
         let len = self.len();
-        unsafe {
-            slice::from_raw_parts_mut(self.xs.ptr_mut(), len)
-        }
+        unsafe { slice::from_raw_parts_mut(self.xs.ptr_mut(), len) }
     }
 }
 
@@ -703,10 +716,12 @@ impl<A: Array> DerefMut for ArrayVec<A> {
 /// ```
 impl<A: Array> From<A> for ArrayVec<A> {
     fn from(array: A) -> Self {
-        ArrayVec { xs: MaybeUninit::from(array), len: Index::from(A::CAPACITY) }
+        ArrayVec {
+            xs: MaybeUninit::from(array),
+            len: Index::from(A::CAPACITY),
+        }
     }
 }
-
 
 /// Iterate the `ArrayVec` with references to each element.
 ///
@@ -722,7 +737,9 @@ impl<A: Array> From<A> for ArrayVec<A> {
 impl<'a, A: Array> IntoIterator for &'a ArrayVec<A> {
     type Item = &'a A::Item;
     type IntoIter = slice::Iter<'a, A::Item>;
-    fn into_iter(self) -> Self::IntoIter { self.iter() }
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
 }
 
 /// Iterate the `ArrayVec` with mutable references to each element.
@@ -739,7 +756,9 @@ impl<'a, A: Array> IntoIterator for &'a ArrayVec<A> {
 impl<'a, A: Array> IntoIterator for &'a mut ArrayVec<A> {
     type Item = &'a mut A::Item;
     type IntoIter = slice::IterMut<'a, A::Item>;
-    fn into_iter(self) -> Self::IntoIter { self.iter_mut() }
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
 }
 
 /// Iterate the `ArrayVec` with each element by value.
@@ -757,10 +776,12 @@ impl<A: Array> IntoIterator for ArrayVec<A> {
     type Item = A::Item;
     type IntoIter = IntoIter<A>;
     fn into_iter(self) -> IntoIter<A> {
-        IntoIter { index: Index::from(0), v: self, }
+        IntoIter {
+            index: Index::from(0),
+            v: self,
+        }
     }
 }
-
 
 /// By-value iterator for `ArrayVec`.
 pub struct IntoIter<A: Array> {
@@ -803,7 +824,7 @@ impl<A: Array> DoubleEndedIterator for IntoIter<A> {
     }
 }
 
-impl<A: Array> ExactSizeIterator for IntoIter<A> { }
+impl<A: Array> ExactSizeIterator for IntoIter<A> {}
 
 impl<A: Array> Drop for IntoIter<A> {
     fn drop(&mut self) {
@@ -812,9 +833,7 @@ impl<A: Array> Drop for IntoIter<A> {
         let len = self.v.len();
         unsafe {
             self.v.set_len(0);
-            let elements = slice::from_raw_parts_mut(
-                self.v.get_unchecked_ptr(index),
-                len - index);
+            let elements = slice::from_raw_parts_mut(self.v.get_unchecked_ptr(index), len - index);
             ptr::drop_in_place(elements);
         }
     }
@@ -845,9 +864,10 @@ where
 }
 
 /// A draining iterator for `ArrayVec`.
-pub struct Drain<'a, A> 
-    where A: Array,
-          A::Item: 'a,
+pub struct Drain<'a, A>
+where
+    A: Array,
+    A::Item: 'a,
 {
     /// Index of tail to preserve
     tail_start: usize,
@@ -862,16 +882,15 @@ unsafe impl<'a, A: Array + Sync> Sync for Drain<'a, A> {}
 unsafe impl<'a, A: Array + Send> Send for Drain<'a, A> {}
 
 impl<'a, A: Array> Iterator for Drain<'a, A>
-    where A::Item: 'a,
+where
+    A::Item: 'a,
 {
     type Item = A::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|elt|
-            unsafe {
-                ptr::read(elt as *const _)
-            }
-        )
+        self.iter
+            .next()
+            .map(|elt| unsafe { ptr::read(elt as *const _) })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -880,27 +899,27 @@ impl<'a, A: Array> Iterator for Drain<'a, A>
 }
 
 impl<'a, A: Array> DoubleEndedIterator for Drain<'a, A>
-    where A::Item: 'a,
+where
+    A::Item: 'a,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|elt|
-            unsafe {
-                ptr::read(elt as *const _)
-            }
-        )
+        self.iter
+            .next_back()
+            .map(|elt| unsafe { ptr::read(elt as *const _) })
     }
 }
 
 impl<'a, A: Array> ExactSizeIterator for Drain<'a, A> where A::Item: 'a {}
 
-impl<'a, A: Array> Drop for Drain<'a, A> 
-    where A::Item: 'a
+impl<'a, A: Array> Drop for Drain<'a, A>
+where
+    A::Item: 'a,
 {
     fn drop(&mut self) {
         // len is currently 0 so panicking while dropping will not cause a double drop.
 
         // exhaust self first
-        while let Some(_) = self.next() { }
+        while let Some(_) = self.next() {}
 
         if self.tail_len > 0 {
             unsafe {
@@ -918,7 +937,8 @@ impl<'a, A: Array> Drop for Drain<'a, A>
 }
 
 struct ScopeExitGuard<T, Data, F>
-    where F: FnMut(&Data, &mut T)
+where
+    F: FnMut(&Data, &mut T),
 {
     value: T,
     data: Data,
@@ -926,21 +946,20 @@ struct ScopeExitGuard<T, Data, F>
 }
 
 impl<T, Data, F> Drop for ScopeExitGuard<T, Data, F>
-    where F: FnMut(&Data, &mut T)
+where
+    F: FnMut(&Data, &mut T),
 {
     fn drop(&mut self) {
         (self.f)(&self.data, &mut self.value)
     }
 }
 
-
-
 /// Extend the `ArrayVec` with an iterator.
-/// 
+///
 /// Does not extract more items than there is space for. No error
 /// occurs if there are more iterator elements.
 impl<A: Array> Extend<A::Item> for ArrayVec<A> {
-    fn extend<T: IntoIterator<Item=A::Item>>(&mut self, iter: T) {
+    fn extend<T: IntoIterator<Item = A::Item>>(&mut self, iter: T) {
         let take = self.capacity() - self.len();
         unsafe {
             let len = self.len();
@@ -955,11 +974,13 @@ impl<A: Array> Extend<A::Item> for ArrayVec<A> {
                 data: len,
                 f: move |&len, self_len| {
                     **self_len = Index::from(len);
-                }
+                },
             };
             let mut iter = iter.into_iter();
             loop {
-                if ptr == end_ptr { break; }
+                if ptr == end_ptr {
+                    break;
+                }
                 if let Some(elt) = iter.next() {
                     raw_ptr_write(ptr, elt);
                     ptr = raw_ptr_add(ptr, 1);
@@ -991,11 +1012,11 @@ unsafe fn raw_ptr_write<T>(ptr: *mut T, value: T) {
 }
 
 /// Create an `ArrayVec` from an iterator.
-/// 
+///
 /// Does not extract more items than there is space for. No error
 /// occurs if there are more iterator elements.
 impl<A: Array> iter::FromIterator<A::Item> for ArrayVec<A> {
-    fn from_iter<T: IntoIterator<Item=A::Item>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = A::Item>>(iter: T) -> Self {
         let mut array = ArrayVec::new();
         array.extend(iter);
         array
@@ -1003,7 +1024,8 @@ impl<A: Array> iter::FromIterator<A::Item> for ArrayVec<A> {
 }
 
 impl<A: Array> Clone for ArrayVec<A>
-    where A::Item: Clone
+where
+    A::Item: Clone,
 {
     fn clone(&self) -> Self {
         self.iter().cloned().collect()
@@ -1027,7 +1049,8 @@ impl<A: Array> Clone for ArrayVec<A>
 }
 
 impl<A: Array> Hash for ArrayVec<A>
-    where A::Item: Hash
+where
+    A::Item: Hash,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&**self, state)
@@ -1035,7 +1058,8 @@ impl<A: Array> Hash for ArrayVec<A>
 }
 
 impl<A: Array> PartialEq for ArrayVec<A>
-    where A::Item: PartialEq
+where
+    A::Item: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
@@ -1043,33 +1067,47 @@ impl<A: Array> PartialEq for ArrayVec<A>
 }
 
 impl<A: Array> PartialEq<[A::Item]> for ArrayVec<A>
-    where A::Item: PartialEq
+where
+    A::Item: PartialEq,
 {
     fn eq(&self, other: &[A::Item]) -> bool {
         **self == *other
     }
 }
 
-impl<A: Array> Eq for ArrayVec<A> where A::Item: Eq { }
+impl<A: Array> Eq for ArrayVec<A> where A::Item: Eq {}
 
 impl<A: Array> Borrow<[A::Item]> for ArrayVec<A> {
-    fn borrow(&self) -> &[A::Item] { self }
+    fn borrow(&self) -> &[A::Item] {
+        self
+    }
 }
 
 impl<A: Array> BorrowMut<[A::Item]> for ArrayVec<A> {
-    fn borrow_mut(&mut self) -> &mut [A::Item] { self }
+    fn borrow_mut(&mut self) -> &mut [A::Item] {
+        self
+    }
 }
 
 impl<A: Array> AsRef<[A::Item]> for ArrayVec<A> {
-    fn as_ref(&self) -> &[A::Item] { self }
+    fn as_ref(&self) -> &[A::Item] {
+        self
+    }
 }
 
 impl<A: Array> AsMut<[A::Item]> for ArrayVec<A> {
-    fn as_mut(&mut self) -> &mut [A::Item] { self }
+    fn as_mut(&mut self) -> &mut [A::Item] {
+        self
+    }
 }
 
-impl<A: Array> fmt::Debug for ArrayVec<A> where A::Item: fmt::Debug {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { (**self).fmt(f) }
+impl<A: Array> fmt::Debug for ArrayVec<A>
+where
+    A::Item: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
 impl<A: Array> Default for ArrayVec<A> {
@@ -1079,7 +1117,10 @@ impl<A: Array> Default for ArrayVec<A> {
     }
 }
 
-impl<A: Array> PartialOrd for ArrayVec<A> where A::Item: PartialOrd {
+impl<A: Array> PartialOrd for ArrayVec<A>
+where
+    A::Item: PartialOrd,
+{
     fn partial_cmp(&self, other: &ArrayVec<A>) -> Option<cmp::Ordering> {
         (**self).partial_cmp(other)
     }
@@ -1101,56 +1142,70 @@ impl<A: Array> PartialOrd for ArrayVec<A> where A::Item: PartialOrd {
     }
 }
 
-impl<A: Array> Ord for ArrayVec<A> where A::Item: Ord {
+impl<A: Array> Ord for ArrayVec<A>
+where
+    A::Item: Ord,
+{
     fn cmp(&self, other: &ArrayVec<A>) -> cmp::Ordering {
         (**self).cmp(other)
     }
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 /// `Write` appends written data to the end of the vector.
 ///
 /// Requires `features="std"`.
-impl<A: Array<Item=u8>> io::Write for ArrayVec<A> {
+impl<A: Array<Item = u8>> io::Write for ArrayVec<A> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let len = cmp::min(self.remaining_capacity(), data.len());
         let _result = self.try_extend_from_slice(&data[..len]);
         debug_assert!(_result.is_ok());
         Ok(len)
     }
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
-impl<T: Serialize, A: Array<Item=T>> Serialize for ArrayVec<A> {
+impl<T: Serialize, A: Array<Item = T>> Serialize for ArrayVec<A> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.collect_seq(self)
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
-impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Deserialize<'de> for ArrayVec<A> {
+impl<'de, T: Deserialize<'de>, A: Array<Item = T>> Deserialize<'de> for ArrayVec<A> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
-        use serde::de::{Visitor, SeqAccess, Error};
+        use serde::de::{Error, SeqAccess, Visitor};
         use std::marker::PhantomData;
 
-        struct ArrayVecVisitor<'de, T: Deserialize<'de>, A: Array<Item=T>>(PhantomData<(&'de (), T, A)>);
+        struct ArrayVecVisitor<'de, T: Deserialize<'de>, A: Array<Item = T>>(
+            PhantomData<(&'de (), T, A)>,
+        );
 
-        impl<'de, T: Deserialize<'de>, A: Array<Item=T>> Visitor<'de> for ArrayVecVisitor<'de, T, A> {
+        impl<'de, T: Deserialize<'de>, A: Array<Item = T>> Visitor<'de> for ArrayVecVisitor<'de, T, A> {
             type Value = ArrayVec<A>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "an array with no more than {} items", A::CAPACITY)
+                write!(
+                    formatter,
+                    "an array with no more than {} items",
+                    A::CAPACITY
+                )
             }
 
             fn visit_seq<SA>(self, mut seq: SA) -> Result<Self::Value, SA::Error>
-                where SA: SeqAccess<'de>,
+            where
+                SA: SeqAccess<'de>,
             {
                 let mut values = ArrayVec::<A>::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ impl<A: Array> ArrayVec<A> {
     /// assert_eq!(array.pop(), None);
     /// ```
     pub fn pop(&mut self) -> Option<A::Item> {
-        if self.len() == 0 {
+        if self.is_empty() {
             return None;
         }
         unsafe {
@@ -397,7 +397,7 @@ impl<A: Array> ArrayVec<A> {
 
     /// Remove the element at `index` and swap the last element into its place.
     ///
-    /// This is a checked version of `.swap_remove`.  
+    /// This is a checked version of `.swap_remove`.
     /// This operation is O(1).
     ///
     /// Return `Some(` *element* `)` if the index is in bounds, else `None`.
@@ -461,7 +461,7 @@ impl<A: Array> ArrayVec<A> {
         if index >= self.len() {
             None
         } else {
-            self.drain(index..index + 1).next()
+            self.drain(index..=index).next()
         }
     }
 
@@ -572,7 +572,7 @@ impl<A: Array> ArrayVec<A> {
         let other_len = other.len();
 
         unsafe {
-            let dst = self.xs.ptr_mut().offset(self_len as isize);
+            let dst = self.xs.ptr_mut().add(self_len);
             ptr::copy_nonoverlapping(other.as_ptr(), dst, other_len);
             self.set_len(self_len + other_len);
         }
@@ -927,8 +927,8 @@ where
                 // memmove back untouched tail, update to new length
                 let start = source_vec.len();
                 let tail = self.tail_start;
-                let src = source_vec.as_ptr().offset(tail as isize);
-                let dst = source_vec.as_mut_ptr().offset(start as isize);
+                let src = source_vec.as_ptr().add(tail);
+                let dst = source_vec.as_mut_ptr().add(start);
                 ptr::copy(src, dst, self.tail_len);
                 source_vec.set_len(start + self.tail_len);
             }
@@ -999,7 +999,7 @@ unsafe fn raw_ptr_add<T>(ptr: *mut T, offset: usize) -> *mut T {
         // Special case for ZST
         (ptr as usize).wrapping_add(offset) as _
     } else {
-        ptr.offset(offset as isize)
+        ptr.add(offset)
     }
 }
 

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -1,5 +1,3 @@
-
-
 use crate::array::Array;
 use std::mem::MaybeUninit as StdMaybeUninit;
 
@@ -9,20 +7,27 @@ pub struct MaybeUninit<T> {
 }
 
 impl<T> Clone for MaybeUninit<T>
-    where T: Copy
+where
+    T: Copy,
 {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<T> MaybeUninit<T> {
     /// Create a new MaybeUninit with uninitialized interior
     pub unsafe fn uninitialized() -> Self {
-        MaybeUninit { inner: StdMaybeUninit::uninit() }
+        MaybeUninit {
+            inner: StdMaybeUninit::uninit(),
+        }
     }
 
     /// Create a new MaybeUninit from the value `v`.
     pub fn from(v: T) -> Self {
-        MaybeUninit { inner: StdMaybeUninit::new(v) }
+        MaybeUninit {
+            inner: StdMaybeUninit::new(v),
+        }
     }
 
     // Raw pointer casts written so that we don't reference or access the
@@ -30,14 +35,16 @@ impl<T> MaybeUninit<T> {
 
     /// Return a raw pointer to the start of the interior array
     pub fn ptr(&self) -> *const T::Item
-        where T: Array
+    where
+        T: Array,
     {
         self.inner.as_ptr() as *const T::Item
     }
 
     /// Return a mut raw pointer to the start of the interior array
     pub fn ptr_mut(&mut self) -> *mut T::Item
-        where T: Array
+    where
+        T: Array,
     {
         self.inner.as_mut_ptr() as *mut T::Item
     }

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -18,14 +18,14 @@ where
 impl<T> MaybeUninit<T> {
     /// Create a new MaybeUninit with uninitialized interior
     pub unsafe fn uninitialized() -> Self {
-        MaybeUninit {
+        Self {
             inner: StdMaybeUninit::uninit(),
         }
     }
 
     /// Create a new MaybeUninit from the value `v`.
     pub fn from(v: T) -> Self {
-        MaybeUninit {
+        Self {
             inner: StdMaybeUninit::new(v),
         }
     }

--- a/src/maybe_uninit.rs
+++ b/src/maybe_uninit.rs
@@ -16,14 +16,14 @@ where
 }
 
 impl<T> MaybeUninit<T> {
-    /// Create a new MaybeUninit with uninitialized interior
+    /// Create a new `MaybeUninit` with uninitialized interior
     pub unsafe fn uninitialized() -> Self {
         Self {
             inner: StdMaybeUninit::uninit(),
         }
     }
 
-    /// Create a new MaybeUninit from the value `v`.
+    /// Create a new `MaybeUninit` from the value `v`.
     pub fn from(v: T) -> Self {
         Self {
             inner: StdMaybeUninit::new(v),

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -5,18 +5,14 @@ extern crate serde_test;
 mod array_vec {
     use arrayvec::ArrayVec;
 
-    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
     #[test]
     fn test_ser_de_empty() {
         let vec = ArrayVec::<[u32; 0]>::new();
 
-        assert_tokens(&vec, &[
-            Token::Seq { len: Some(0) },
-            Token::SeqEnd,
-        ]);
+        assert_tokens(&vec, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
     }
-
 
     #[test]
     fn test_ser_de() {
@@ -25,55 +21,57 @@ mod array_vec {
         vec.push(55);
         vec.push(123);
 
-        assert_tokens(&vec, &[
-            Token::Seq { len: Some(3) },
-            Token::U32(20),
-            Token::U32(55),
-            Token::U32(123),
-            Token::SeqEnd,
-        ]);
+        assert_tokens(
+            &vec,
+            &[
+                Token::Seq { len: Some(3) },
+                Token::U32(20),
+                Token::U32(55),
+                Token::U32(123),
+                Token::SeqEnd,
+            ],
+        );
     }
 
     #[test]
     fn test_de_too_large() {
-        assert_de_tokens_error::<ArrayVec<[u32; 2]>>(&[
-            Token::Seq { len: Some(3) },
-            Token::U32(13),
-            Token::U32(42),
-            Token::U32(68),
-        ], "invalid length 3, expected an array with no more than 2 items");
+        assert_de_tokens_error::<ArrayVec<[u32; 2]>>(
+            &[
+                Token::Seq { len: Some(3) },
+                Token::U32(13),
+                Token::U32(42),
+                Token::U32(68),
+            ],
+            "invalid length 3, expected an array with no more than 2 items",
+        );
     }
 }
 
 mod array_string {
     use arrayvec::ArrayString;
 
-    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
     #[test]
     fn test_ser_de_empty() {
         let string = ArrayString::<[u8; 0]>::new();
 
-        assert_tokens(&string, &[
-            Token::Str(""),
-        ]);
+        assert_tokens(&string, &[Token::Str("")]);
     }
-
 
     #[test]
     fn test_ser_de() {
         let string = ArrayString::<[u8; 9]>::from("1234 abcd")
             .expect("expected exact specified capacity to be enough");
 
-        assert_tokens(&string, &[
-            Token::Str("1234 abcd"),
-        ]);
+        assert_tokens(&string, &[Token::Str("1234 abcd")]);
     }
 
     #[test]
     fn test_de_too_large() {
-        assert_de_tokens_error::<ArrayString<[u8; 2]>>(&[
-            Token::Str("afd")
-        ], "invalid length 3, expected a string no more than 2 bytes long");
+        assert_de_tokens_error::<ArrayString<[u8; 2]>>(
+            &[Token::Str("afd")],
+            "invalid length 3, expected a string no more than 2 bytes long",
+        );
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,13 +1,13 @@
 extern crate arrayvec;
-#[macro_use] extern crate matches;
+#[macro_use]
+extern crate matches;
 
-use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
-use std::mem;
+use arrayvec::ArrayVec;
 use arrayvec::CapacityError;
+use std::mem;
 
 use std::collections::HashMap;
-
 
 #[test]
 fn test_simple() {
@@ -215,7 +215,6 @@ fn test_drop_panics() {
     // Check that all the elements drop, even if the first drop panics.
     assert_eq!(flag.get(), 3);
 
-
     flag.set(0);
     {
         let mut array = ArrayVec::<[Bump; 16]>::new();
@@ -235,8 +234,6 @@ fn test_drop_panics() {
         // Check that all the tail elements drop, even if the first drop panics.
         assert_eq!(flag.get(), tail_len as i32);
     }
-
-
 }
 
 #[test]
@@ -435,7 +432,7 @@ fn test_into_inner_3_() {
     assert_eq!(v.into_inner().unwrap(), [1, 2, 3, 4]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_write() {
     use std::io::Write;
@@ -470,7 +467,7 @@ fn array_clone_from() {
     assert_eq!(&t, &reference[..]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_string() {
     use std::error::Error;
@@ -507,7 +504,7 @@ fn test_string() {
 #[test]
 fn test_string_from() {
     let text = "hello world";
-	// Test `from` constructor
+    // Test `from` constructor
     let u = ArrayString::<[_; 11]>::from(text).unwrap();
     assert_eq!(&u, text);
     assert_eq!(u.len(), text.len());
@@ -553,7 +550,6 @@ fn test_string_push() {
     assert_eq!("abcαβx", &s[..]);
     assert!(s.try_push('x').is_err());
 }
-
 
 #[test]
 fn test_insert_at_length() {
@@ -645,14 +641,14 @@ fn test_default() {
     assert_eq!(v.len(), 0);
 }
 
-#[cfg(feature="array-sizes-33-128")]
+#[cfg(feature = "array-sizes-33-128")]
 #[test]
 fn test_sizes_33_128() {
     ArrayVec::from([0u8; 52]);
     ArrayVec::from([0u8; 127]);
 }
 
-#[cfg(feature="array-sizes-129-255")]
+#[cfg(feature = "array-sizes-129-255")]
 #[test]
 fn test_sizes_129_255() {
     ArrayVec::from([0u8; 237]);


### PR DESCRIPTION
This PR does a lot of stuff:
- first I applied `cargo fmt` to make the code more readable (my editor automatically does this, when I save a file)
- I then fixed all clippy lints except for the following
> warning: you have declared `#[inline(always)]` on `to_usize`. This is usually a bad idea (inline_always lint)

[link](https://rust-lang.github.io/rust-clippy/master/#inline_always)
- I also went over the entire documentation of `ArrayVec` and made it more readable, by adding sections and removing redundant code in the examples