### PR TITLE
enable another unwinding test in Miri

### DIFF
--- a/src/char.rs
+++ b/src/char.rs
@@ -63,7 +63,7 @@ pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, E
 
 
 #[test]
-#[cfg(not(miri))] // Miri is too slow
+#[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_encode_utf8() {
     // Test that all codepoints are encoded correctly
     let mut data = [0u8; 16];

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -165,7 +165,6 @@ fn test_drop() {
 }
 
 #[test]
-#[cfg(not(miri))] // Miri does not support unwinding
 fn test_drop_panics() {
     use std::cell::Cell;
     use std::panic::catch_unwind;


### PR DESCRIPTION
I overlooked this when preparing https://github.com/bluss/arrayvec/pull/155.