### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,11 +33,7 @@ const CAPERROR: &'static str = "insufficient capacity";
 
 #[cfg(feature="std")]
 /// Requires `features="std"`.
-impl<T: Any> Error for CapacityError<T> {
-    fn description(&self) -> &str {
-        CAPERROR
-    }
-}
+impl<T: Any> Error for CapacityError<T> {}
 
 impl<T> fmt::Display for CapacityError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `description`

Related PR: https://github.com/rust-lang/rust/pull/66919