### PR TITLE
Use `add` instead of `offset` so we don't need to cast to isize.

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -230,7 +230,7 @@ impl<A> ArrayString<A>
             return Err(CapacityError::new(s));
         }
         unsafe {
-            let dst = self.xs.ptr_mut().offset(self.len() as isize);
+            let dst = self.xs.ptr_mut().add(self.len());
             let src = s.as_ptr();
             ptr::copy_nonoverlapping(src, dst, s.len());
             let newl = self.len() + s.len();
@@ -321,8 +321,8 @@ impl<A> ArrayString<A>
         let next = idx + ch.len_utf8();
         let len = self.len();
         unsafe {
-            ptr::copy(self.xs.ptr().offset(next as isize),
-                      self.xs.ptr_mut().offset(idx as isize),
+            ptr::copy(self.xs.ptr().add(next),
+                      self.xs.ptr_mut().add(idx),
                       len - next);
             self.set_len(len - (next - idx));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,7 +555,7 @@ impl<A: Array> ArrayVec<A> {
         let other_len = other.len();
 
         unsafe {
-            let dst = self.xs.ptr_mut().offset(self_len as isize);
+            let dst = self.xs.ptr_mut().add(self_len);
             ptr::copy_nonoverlapping(other.as_ptr(), dst, other_len);
             self.set_len(self_len + other_len);
         }
@@ -937,8 +937,8 @@ impl<'a, A: Array> Drop for Drain<'a, A>
                 // memmove back untouched tail, update to new length
                 let start = source_vec.len();
                 let tail = self.tail_start;
-                let src = source_vec.as_ptr().offset(tail as isize);
-                let dst = source_vec.as_mut_ptr().offset(start as isize);
+                let src = source_vec.as_ptr().add(tail);
+                let dst = source_vec.as_mut_ptr().add(start);
                 ptr::copy(src, dst, self.tail_len);
                 source_vec.set_len(start + self.tail_len);
             }
@@ -1007,7 +1007,7 @@ unsafe fn raw_ptr_add<T>(ptr: *mut T, offset: usize) -> *mut T {
         // Special case for ZST
         (ptr as usize).wrapping_add(offset) as _
     } else {
-        ptr.offset(offset as isize)
+        ptr.add(offset)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>