### PR TITLE
Impl TryFrom<fmt::Arguments<'a>> for ArrayString

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -594,3 +594,17 @@ where
         Ok(v)
     }
 }
+
+impl<'a, A> TryFrom<fmt::Arguments<'a>> for ArrayString<A>
+where
+    A: Array<Item = u8> + Copy
+{
+    type Error = CapacityError<fmt::Error>;
+
+    fn try_from(f: fmt::Arguments<'a>) -> Result<Self, Self::Error> {
+        use fmt::Write;
+        let mut v = Self::new();
+        v.write_fmt(f).map_err(|e| CapacityError::new(e))?;
+        Ok(v)
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -686,3 +686,10 @@ fn test_extend_zst() {
     assert_eq!(&array[..], &[Z; 5]);
     assert_eq!(array.len(), 5);
 }
+
+#[test]
+fn test_try_from_argument() {
+    use core::convert::TryFrom;
+    let v = ArrayString::<[u8; 16]>::try_from(format_args!("Hello {}", 123)).unwrap();
+    assert_eq!(&v, "Hello 123");
+}


### PR DESCRIPTION
Shortcut for

```rust
use core::fmt::Write;
let mut v = Self::new();
v.write_fmt(format_args!("Something -> {}", 123)).map_err(|e| CapacityError::new(e))?;

...
```

