### PR TITLE
Use u32 for the length field in arrayvec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Recent Changes (arrayvec)
 
   The New type syntax is `ArrayVec<T, CAP>` where `CAP` is the arrayvec capacity.
   For arraystring the syntax is `ArrayString<CAP>`.
-  Change by @bluss.
+
+  Length is stored internally as u32; this limits the maximum capacity. The size
+  of the `ArrayVec` or `ArrayString` structs for the same capacity may grow
+  slightly compared with the previous version (depending on padding requirements
+  for the element type). Change by @bluss.
 
 - Arrayvec's `.extend()` and `FromIterator`/`.collect()` to arrayvec now
   **panic** if the capacity of the arrayvec is exceeded. Change by @bluss.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **arrayvec** provides the types `ArrayVec` and `ArrayString`: 
+//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]: 
 //! array-backed vector and string types, which store their contents inline.
 //!
 //! The arrayvec package has the following cargo features:
@@ -21,7 +21,7 @@
 //!
 //! This version of arrayvec requires Rust 1.51 or later.
 //!
-#![doc(html_root_url="https://docs.rs/arrayvec/0.5/")]
+#![doc(html_root_url="https://docs.rs/arrayvec/0.6/")]
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(feature="unstable-const-fn", feature(const_fn, const_maybe_uninit_assume_init, const_panic))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,25 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.5/")]
 #![cfg_attr(not(feature="std"), no_std)]
-#![cfg_attr(feature="unstable-const-fn", feature(const_fn, const_maybe_uninit_assume_init))]
+#![cfg_attr(feature="unstable-const-fn", feature(const_fn, const_maybe_uninit_assume_init, const_panic))]
 
 #[cfg(feature="serde")]
 extern crate serde;
 
 #[cfg(not(feature="std"))]
 extern crate core as std;
+
+pub(crate) type LenUint = u32;
+
+macro_rules! assert_capacity_limit {
+    ($cap:expr) => {
+        if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
+            if CAP > LenUint::MAX as usize {
+                panic!("ArrayVec: largest supported capacity is u32::MAX")
+            }
+        }
+    }
+}
 
 mod arrayvec_impl;
 mod arrayvec;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -295,17 +295,17 @@ fn test_compact_size() {
     // 4 bytes + padding + length
     type ByteArray = ArrayVec<u8,  4>;
     println!("{}", mem::size_of::<ByteArray>());
-    assert!(mem::size_of::<ByteArray>() <= 2 * mem::size_of::<usize>());
+    assert!(mem::size_of::<ByteArray>() <= 2 * mem::size_of::<u32>());
 
     // just length
     type EmptyArray = ArrayVec<u8,  0>;
     println!("{}", mem::size_of::<EmptyArray>());
-    assert!(mem::size_of::<EmptyArray>() <= mem::size_of::<usize>());
+    assert!(mem::size_of::<EmptyArray>() <= mem::size_of::<u32>());
 
     // 3 elements + padding + length
     type QuadArray = ArrayVec<u32,  3>;
     println!("{}", mem::size_of::<QuadArray>());
-    assert!(mem::size_of::<QuadArray>() <= 4 * 4 + mem::size_of::<usize>());
+    assert!(mem::size_of::<QuadArray>() <= 4 * 4 + mem::size_of::<u32>());
 }
 
 #[test]
@@ -710,4 +710,20 @@ fn test_try_from_argument() {
     use core::convert::TryFrom;
     let v = ArrayString::<16>::try_from(format_args!("Hello {}", 123)).unwrap();
     assert_eq!(&v, "Hello 123");
+}
+
+#[test]
+fn allow_max_capacity_arrayvec_type() {
+    // this type is allowed to be used (but can't be constructed)
+    let _v: ArrayVec<(), {usize::MAX}>;
+}
+
+#[should_panic(expected="ArrayVec: largest supported")]
+#[test]
+fn deny_max_capacity_arrayvec_value() {
+    if mem::size_of::<usize>() <= mem::size_of::<u32>() {
+        panic!("This test does not work on this platform. 'ArrayVec: largest supported'");
+    }
+    // this type is allowed to be used (but can't be constructed)
+    let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new();
 }


### PR DESCRIPTION
Store the length as u32 internally. This is to shrink the size of the
ArrayVec value (when possible, depending on element type).

Inline storage vectors larger than u32::MAX are very unlikely to be
useful - for these cases, prefer using Vec instead.

It's not possible to have the CAP type parameter be of type u32 (missing
features in const evaluation/const generics). We also have to panic at
runtime instead of having a static assertion for capacity, for similar
reasons.