### PR TITLE
Made ArrayVec::new and ArrayString::new const fns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
           - rust: nightly
             features: serde
             experimental: false
-          - rust: nightly
-            features: serde unstable-const-fn
-            experimental: true
 
     steps:
       - uses: actions/checkout@v2

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -14,6 +14,7 @@ use std::str::Utf8Error;
 use crate::CapacityError;
 use crate::LenUint;
 use crate::char::encode_utf8;
+use crate::utils::MakeMaybeUninit;
 
 #[cfg(feature="serde")]
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
@@ -58,20 +59,9 @@ impl<const CAP: usize> ArrayString<CAP>
     /// assert_eq!(&string[..], "foo");
     /// assert_eq!(string.capacity(), 16);
     /// ```
-    #[cfg(not(feature="unstable-const-fn"))]
-    pub fn new() -> ArrayString<CAP> {
-        assert_capacity_limit!(CAP);
-        unsafe {
-            ArrayString { xs: MaybeUninit::uninit().assume_init(), len: 0 }
-        }
-    }
-
-    #[cfg(feature="unstable-const-fn")]
     pub const fn new() -> ArrayString<CAP> {
         assert_capacity_limit!(CAP);
-        unsafe {
-            ArrayString { xs: MaybeUninit::uninit().assume_init(), len: 0 }
-        }
+        ArrayString { xs: MakeMaybeUninit::ARRAY, len: 0 }
     }
 
     /// Return the length of the string.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -23,6 +23,7 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use crate::LenUint;
 use crate::errors::CapacityError;
 use crate::arrayvec_impl::ArrayVecImpl;
+use crate::utils::MakeMaybeUninit;
 
 /// A vector with a fixed capacity.
 ///
@@ -76,20 +77,9 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(&array[..], &[1, 2]);
     /// assert_eq!(array.capacity(), 16);
     /// ```
-    #[cfg(not(feature="unstable-const-fn"))]
-    pub fn new() -> ArrayVec<T, CAP> {
-        assert_capacity_limit!(CAP);
-        unsafe {
-            ArrayVec { xs: MaybeUninit::uninit().assume_init(), len: 0 }
-        }
-    }
-
-    #[cfg(feature="unstable-const-fn")]
     pub const fn new() -> ArrayVec<T, CAP> {
         assert_capacity_limit!(CAP);
-        unsafe {
-            ArrayVec { xs: MaybeUninit::uninit().assume_init(), len: 0 }
-        }
+        ArrayVec { xs: MakeMaybeUninit::ARRAY, len: 0 }
     }
 
     /// Return the number of elements in the `ArrayVec`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,9 @@
 //!   - Optional
 //!   - Enable serialization for ArrayVec and ArrayString using serde 1.x
 //!
-//! - `unstable-const-fn`
-//!   - Optional
-//!   - Makes [`ArrayVec::new`] and [`ArrayString::new`] `const fn`s,
-//!     using the nightly `const_fn` feature.
-//!   - Unstable and requires nightly.
+//! - `unstable-const-fn`: **deprecated**,
+//! used to be needed to make [`ArrayVec::new`] and [`ArrayString::new`] `const fn`s,
+//! now they are always `const fn`s.
 //!
 //! ## Rust Version
 //!
@@ -23,7 +21,6 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.6/")]
 #![cfg_attr(not(feature="std"), no_std)]
-#![cfg_attr(feature="unstable-const-fn", feature(const_fn, const_maybe_uninit_assume_init, const_panic))]
 
 #[cfg(feature="serde")]
 extern crate serde;
@@ -37,7 +34,7 @@ macro_rules! assert_capacity_limit {
     ($cap:expr) => {
         if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
             if $cap > LenUint::MAX as usize {
-                panic!("ArrayVec: largest supported capacity is u32::MAX")
+                [/*ArrayVec: largest supported capacity is u32::MAX*/][$cap]
             }
         }
     }
@@ -48,6 +45,7 @@ mod arrayvec;
 mod array_string;
 mod char;
 mod errors;
+mod utils;
 
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 //!   - Optional
 //!   - Enable serialization for ArrayVec and ArrayString using serde 1.x
 //!
-//! - `unstable-const-fn`: **deprecated**,
-//! used to be needed to make [`ArrayVec::new`] and [`ArrayString::new`] `const fn`s,
-//! now they are always `const fn`s.
+//! - `unstable-const-fn`
+//!   - **deprecated** (has no effect)
+//!   - Not needed, [`ArrayVec::new`] and [`ArrayString::new`] are always `const fn` now
 //!
 //! ## Rust Version
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+
+pub(crate) struct MakeMaybeUninit<T, const N: usize>(PhantomData<fn() -> T>);
+
+impl<T, const N: usize> MakeMaybeUninit<T, N> {
+    pub(crate) const VALUE: MaybeUninit<T> = MaybeUninit::uninit();
+
+    pub(crate) const ARRAY: [MaybeUninit<T>; N] = [Self::VALUE; N];
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -718,12 +718,37 @@ fn allow_max_capacity_arrayvec_type() {
     let _v: ArrayVec<(), {usize::MAX}>;
 }
 
-#[should_panic(expected="ArrayVec: largest supported")]
+#[should_panic(expected="index out of bounds")]
 #[test]
 fn deny_max_capacity_arrayvec_value() {
     if mem::size_of::<usize>() <= mem::size_of::<u32>() {
-        panic!("This test does not work on this platform. 'ArrayVec: largest supported'");
+        panic!("This test does not work on this platform. 'index out of bounds'");
     }
     // this type is allowed to be used (but can't be constructed)
     let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new();
 }
+
+#[test]
+fn test_arrayvec_const_constructible() {
+    const OF_U8: ArrayVec<Vec<u8>, 10> = ArrayVec::new();
+
+    let mut var = OF_U8;
+    assert!(var.is_empty());
+    assert_eq!(var, ArrayVec::new());
+    var.push(vec![3, 5, 8]);
+    assert_eq!(var[..], [vec![3, 5, 8]]);
+}
+
+
+#[test]
+fn test_arraystring_const_constructible() {
+    const AS: ArrayString<10> = ArrayString::new();
+
+    let mut var = AS;
+    assert!(var.is_empty());
+    assert_eq!(var, ArrayString::new());
+    var.push_str("hello");
+    assert_eq!(var, *"hello");
+}
+
+


### PR DESCRIPTION
Followup to this comment: https://github.com/bluss/arrayvec/issues/93#issuecomment-808920790

Fixes #93 