### PR TITLE
Use `truncate` in `clone_from`

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1079,9 +1079,7 @@ impl<T, const CAP: usize> Clone for ArrayVec<T, CAP>
 
         if prefix < self.len() {
             // rhs was shorter
-            for _ in 0..self.len() - prefix {
-                self.pop();
-            }
+            self.truncate(prefix);
         } else {
             let rhs_elems = &rhs[self.len()..];
             self.extend_from_slice(rhs_elems);


### PR DESCRIPTION
This is more efficient because it calls `drop_in_place` on the tail instead on `pop`ing each element separately.