### PR TITLE
Upgrade length/capacity-related functions to const-fn

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -152,6 +152,19 @@ impl<const CAP: usize> ArrayString<CAP>
     /// ```
     pub fn is_full(&self) -> bool { self.len() == self.capacity() }
 
+    /// Returns the capacity left in the `ArrayString`.
+    ///
+    /// ```
+    /// use arrayvec::ArrayString;
+    ///
+    /// let mut string = ArrayString::<3>::from("abc").unwrap();
+    /// string.pop();
+    /// assert_eq!(string.remaining_capacity(), 1);
+    /// ```
+    pub const fn remaining_capacity(&self) -> usize {
+        self.capacity() - self.len()
+    }
+
     /// Adds the given char to the end of the string.
     ///
     /// ***Panics*** if the backing array is not large enough to fit the additional char.

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -82,11 +82,11 @@ impl<const CAP: usize> ArrayString<CAP>
 
     /// Return the length of the string.
     #[inline]
-    pub fn len(&self) -> usize { self.len as usize }
+    pub const fn len(&self) -> usize { self.len as usize }
 
     /// Returns whether the string is empty.
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub const fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Create a new `ArrayString` from a `str`.
     ///
@@ -138,7 +138,7 @@ impl<const CAP: usize> ArrayString<CAP>
     /// assert_eq!(string.capacity(), 3);
     /// ```
     #[inline(always)]
-    pub fn capacity(&self) -> usize { CAP }
+    pub const fn capacity(&self) -> usize { CAP }
 
     /// Return if the `ArrayString` is completely filled.
     ///
@@ -150,7 +150,7 @@ impl<const CAP: usize> ArrayString<CAP>
     /// string.push_str("A");
     /// assert!(string.is_full());
     /// ```
-    pub fn is_full(&self) -> bool { self.len() == self.capacity() }
+    pub const fn is_full(&self) -> bool { self.len() == self.capacity() }
 
     /// Returns the capacity left in the `ArrayString`.
     ///

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -108,7 +108,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(array.len(), 2);
     /// ```
     #[inline(always)]
-    pub fn len(&self) -> usize { self.len as usize }
+    pub const fn len(&self) -> usize { self.len as usize }
 
     /// Returns whether the `ArrayVec` is empty.
     ///
@@ -120,7 +120,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(array.is_empty(), true);
     /// ```
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub const fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Return the capacity of the `ArrayVec`.
     ///
@@ -131,7 +131,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(array.capacity(), 3);
     /// ```
     #[inline(always)]
-    pub fn capacity(&self) -> usize { CAP }
+    pub const fn capacity(&self) -> usize { CAP }
 
     /// Return true if the `ArrayVec` is completely filled to its capacity, false otherwise.
     ///
@@ -143,7 +143,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// array.push(1);
     /// assert!(array.is_full());
     /// ```
-    pub fn is_full(&self) -> bool { self.len() == self.capacity() }
+    pub const fn is_full(&self) -> bool { self.len() == self.capacity() }
 
     /// Returns the capacity left in the `ArrayVec`.
     ///
@@ -154,7 +154,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// array.pop();
     /// assert_eq!(array.remaining_capacity(), 1);
     /// ```
-    pub fn remaining_capacity(&self) -> usize {
+    pub const fn remaining_capacity(&self) -> usize {
         self.capacity() - self.len()
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,7 +12,7 @@ pub struct CapacityError<T = ()> {
 
 impl<T> CapacityError<T> {
     /// Create a new `CapacityError` from `element`.
-    pub fn new(element: T) -> CapacityError<T> {
+    pub const fn new(element: T) -> CapacityError<T> {
         CapacityError {
             element: element,
         }


### PR DESCRIPTION
The following are upgraded:
- `Array::len`
- `Array::is_empty`
- `Array::capacity`
- `Array::is_full`
- `Array::remaining_capacity` (added one to `ArrayString` because it didn't exist)
- `CapacityError::new`