### PR TITLE
Add two doc examples

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -30,6 +30,24 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 ///
 /// The string is a contiguous value that you can store directly on the stack
 /// if needed.
+/// 
+/// ## Example
+/// ```rust
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use arrayvec::ArrayString;
+/// 
+/// // Create a new ArrayString with a capacity of 12
+/// let mut hello = ArrayString::<12>::from("Hello")?;
+/// 
+/// let mut hello_world = hello.clone();
+/// hello_world.push_str(" world!");
+/// assert_eq!(hello_world.as_str(), "Hello world!");
+/// 
+/// // Too long!
+/// assert!(hello.try_push_str(" to the world and the universe!").is_err());
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Copy)]
 pub struct ArrayString<const CAP: usize> {
     // the `len` first elements of the array are initialized

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,20 @@
 //!   - Optional
 //!   - Enable serialization for ArrayVec and ArrayString using serde 1.x
 //!
+//! ## Example
+//! ```rust
+//! use arrayvec::{ArrayVec, CapacityError};
+//! 
+//! // Creates a new ArrayVec with a capacity of 3 and contents [1, 2, 3].
+//! let mut stack = ArrayVec::from([1, 2, 3]);
+//! assert_eq!(stack.pop(), Some(3));
+//! stack.push(4);
+//! 
+//! // Now the stack is full:
+//! assert!(stack.is_full());
+//! assert_eq!(stack.try_push(5), Err(CapacityError::new(5)))
+//! ```
+//! 
 //! ## Rust Version
 //!
 //! This version of arrayvec requires Rust 1.51 or later.


### PR DESCRIPTION
Adds two doc examples, one in the crate root and another for `ArrayString`.