### PR TITLE
Add PartialEq implementations

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -457,10 +457,24 @@ impl<const CAP: usize> PartialEq<str> for ArrayString<CAP>
     }
 }
 
+impl<const CAP: usize> PartialEq<&str> for ArrayString<CAP>
+{
+    fn eq(&self, rhs: &&str) -> bool {
+        &**self == *rhs
+    }
+}
+
 impl<const CAP: usize> PartialEq<ArrayString<CAP>> for str
 {
     fn eq(&self, rhs: &ArrayString<CAP>) -> bool {
         self == &**rhs
+    }
+}
+
+impl<const CAP: usize> PartialEq<ArrayString<CAP>> for &str
+{
+    fn eq(&self, rhs: &ArrayString<CAP>) -> bool {
+        *self == &**rhs
     }
 }
 

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1132,21 +1132,27 @@ impl<T, const CAP: usize> Hash for ArrayVec<T, CAP>
     }
 }
 
-impl<T, const CAP: usize> PartialEq for ArrayVec<T, CAP>
-    where T: PartialEq
-{
-    fn eq(&self, other: &Self) -> bool {
-        **self == **other
-    }
+macro_rules! impl_slice_eq {
+    ([$($vars:tt)*] $lhs:ty, $rhs:ty) => {
+        impl<T, U, $($vars)*> PartialEq<$rhs> for $lhs
+        where T: PartialEq<U> {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                self[..] == other[..]
+            }
+        }
+    };
 }
 
-impl<T, const CAP: usize> PartialEq<[T]> for ArrayVec<T, CAP>
-    where T: PartialEq
-{
-    fn eq(&self, other: &[T]) -> bool {
-        **self == *other
-    }
-}
+impl_slice_eq!([const C0: usize, const C1: usize] ArrayVec<T, C0>, ArrayVec<U, C1>);
+impl_slice_eq!([const C: usize] ArrayVec<T, C>, &[U]);
+impl_slice_eq!([const C: usize] ArrayVec<T, C>, &mut [U]);
+impl_slice_eq!([const C: usize] &[T], ArrayVec<U, C>);
+impl_slice_eq!([const C: usize] &mut [T], ArrayVec<U, C>);
+impl_slice_eq!([const C: usize] [T], ArrayVec<U, C>);
+impl_slice_eq!([const C: usize] ArrayVec<T, C>, [U]);
+impl_slice_eq!([const C: usize, const N: usize] ArrayVec<T, C>, [U; N]);
+impl_slice_eq!([const C: usize, const N: usize] ArrayVec<T, C>, &[U; N]);
 
 impl<T, const CAP: usize> Eq for ArrayVec<T, CAP> where T: Eq { }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -47,9 +47,9 @@ fn test_extend_from_slice() {
 
     vec.try_extend_from_slice(&[1, 2, 3]).unwrap();
     assert_eq!(vec.len(), 3);
-    assert_eq!(&vec[..], &[1, 2, 3]);
+    assert_eq!(vec, [1, 2, 3]);
     assert_eq!(vec.pop(), Some(3));
-    assert_eq!(&vec[..], &[1, 2]);
+    assert_eq!(vec, [1, 2]);
 }
 
 #[test]
@@ -528,8 +528,8 @@ fn test_string() {
     let text = "hello world";
     let mut s = ArrayString::<16>::new();
     s.try_push_str(text).unwrap();
-    assert_eq!(&s, text);
-    assert_eq!(text, &s);
+    assert_eq!(s, text);
+    assert_eq!(text, s);
 
     // Make sure Hash / Eq / Borrow match up so we can use HashMap
     let mut map = HashMap::new();
@@ -611,7 +611,7 @@ fn test_insert_at_length() {
     let result1 = v.try_insert(0, "a");
     let result2 = v.try_insert(1, "b");
     assert!(result1.is_ok() && result2.is_ok());
-    assert_eq!(&v[..], &["a", "b"]);
+    assert_eq!(v, ["a", "b"]);
 }
 
 #[should_panic]
@@ -737,6 +737,15 @@ fn test_try_from_argument() {
 }
 
 #[test]
+fn test_nested_eq() {
+    let array: ArrayVec<ArrayVec<_, 2>, 5> = (0..3)
+        .map(|i| ArrayVec::from([i, i + 1]))
+        .collect();
+
+    assert_eq!(array, [[0, 1], [1, 2], [2, 3]]);
+}
+
+#[test]
 fn allow_max_capacity_arrayvec_type() {
     // this type is allowed to be used (but can't be constructed)
     let _v: ArrayVec<(), {usize::MAX}>;
@@ -768,7 +777,7 @@ fn test_arrayvec_const_constructible() {
 
     let mut var = OF_U8;
     assert!(var.is_empty());
-    assert_eq!(var, ArrayVec::new());
+    assert_eq!(var, ArrayVec::<Vec<u8>, 10>::new());
     var.push(vec![3, 5, 8]);
     assert_eq!(var[..], [vec![3, 5, 8]]);
 }
@@ -790,4 +799,14 @@ fn test_arraystring_zero_filled_has_some_sanity_checks() {
     let string = ArrayString::<4>::zero_filled();
     assert_eq!(string.as_str(), "\0\0\0\0");
     assert_eq!(string.len(), 4);
+}
+
+#[test]
+fn test_vec_of_strings_equality() {
+    let vec = ArrayVec::from([
+        ArrayString::<8>::from("one").unwrap(),
+        ArrayString::<8>::from("two").unwrap(),
+        ArrayString::<8>::from("three").unwrap(),
+    ]);
+    assert_eq!(vec, ["one", "two", "three"]);
 }


### PR DESCRIPTION
This allows nested comparisons:
```rust
fn test_nested_eq() {
    let array: ArrayVec<ArrayVec<_, 2>, 5> = (0..3)
        .map(|i| ArrayVec::from([i, i + 1]))
        .collect();

    assert_eq!(array, [[0, 1], [1, 2], [2, 3]]);
}

fn test_vec_of_strings_equality() {
    let vec = ArrayVec::from([
        ArrayString::<8>::from("one").unwrap(),
        ArrayString::<8>::from("two").unwrap(),
        ArrayString::<8>::from("three").unwrap(),
    ]);
    assert_eq!(vec, ["one", "two", "three"]);
}
```
Implementation is similar to std https://doc.rust-lang.org/src/alloc/vec/partial_eq.rs.html#7