### PR TITLE
Implement AsMut<str> for ArrayString

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -479,6 +479,11 @@ impl<const CAP: usize> Borrow<str> for ArrayString<CAP>
     fn borrow(&self) -> &str { self }
 }
 
+impl<const CAP: usize> AsMut<str> for ArrayString<CAP>
+{
+    fn as_mut(&mut self) -> &mut str { self }
+}
+
 impl<const CAP: usize> AsRef<str> for ArrayString<CAP>
 {
     fn as_ref(&self) -> &str { self }


### PR DESCRIPTION
`ArraySting` already implements `DerefMut` so `AsMut` is like a missing piece

It is worth noting that `String` also implements `AsMut`