### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -435,8 +435,8 @@ impl<const CAP: usize> DerefMut for ArrayString<CAP>
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut str {
+        let len = self.len();
         unsafe {
-            let len = self.len();
             let sl = slice::from_raw_parts_mut(self.as_mut_ptr(), len);
             str::from_utf8_unchecked_mut(sl)
         }

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -856,9 +856,9 @@ impl<T, const CAP: usize> Iterator for IntoIter<T, CAP> {
         if self.index == self.v.len() {
             None
         } else {
+            let index = self.index;
+            self.index = index + 1;
             unsafe {
-                let index = self.index;
-                self.index = index + 1;
                 Some(ptr::read(self.v.get_unchecked_ptr(index)))
             }
         }
@@ -1071,8 +1071,8 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     {
         let take = self.capacity() - self.len();
         debug_assert!(slice.len() <= take);
+        let slice = if take < slice.len() { &slice[..take] } else { slice };
         unsafe {
-            let slice = if take < slice.len() { &slice[..take] } else { slice };
             self.extend_from_iter::<_, false>(slice.iter().cloned());
         }
     }

--- a/src/arrayvec_impl.rs
+++ b/src/arrayvec_impl.rs
@@ -61,8 +61,8 @@ pub(crate) trait ArrayVecImpl {
         if self.len() == 0 {
             return None;
         }
+        let new_len = self.len() - 1;
         unsafe {
-            let new_len = self.len() - 1;
             self.set_len(new_len);
             Some(ptr::read(self.as_ptr().add(new_len)))
         }
@@ -73,8 +73,8 @@ pub(crate) trait ArrayVecImpl {
     }
 
     fn truncate(&mut self, new_len: usize) {
+        let len = self.len();
         unsafe {
-            let len = self.len();
             if new_len < len {
                 self.set_len(new_len);
                 let tail = slice::from_raw_parts_mut(self.as_mut_ptr().add(new_len), len - new_len);


### PR DESCRIPTION
In these function you use the unsafe keyword for some safe expressions. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 