### PR TITLE
apply standard rustfmt style

### DIFF
--- a/benches/arraystring.rs
+++ b/benches/arraystring.rs
@@ -1,6 +1,6 @@
-
 extern crate arrayvec;
-#[macro_use] extern crate bencher;
+#[macro_use]
+extern crate bencher;
 
 use arrayvec::ArrayString;
 
@@ -10,8 +10,7 @@ fn try_push_c(b: &mut Bencher) {
     let mut v = ArrayString::<512>::new();
     b.iter(|| {
         v.clear();
-        while v.try_push('c').is_ok() {
-        }
+        while v.try_push('c').is_ok() {}
         v.len()
     });
     b.bytes = v.capacity() as u64;
@@ -21,8 +20,7 @@ fn try_push_alpha(b: &mut Bencher) {
     let mut v = ArrayString::<512>::new();
     b.iter(|| {
         v.clear();
-        while v.try_push('α').is_ok() {
-        }
+        while v.try_push('α').is_ok() {}
         v.len()
     });
     b.bytes = v.capacity() as u64;
@@ -85,6 +83,13 @@ fn push_string(b: &mut Bencher) {
     b.bytes = v.capacity() as u64;
 }
 
-benchmark_group!(benches, try_push_c, try_push_alpha, try_push_string, push_c,
-                 push_alpha, push_string);
+benchmark_group!(
+    benches,
+    try_push_c,
+    try_push_alpha,
+    try_push_string,
+    push_c,
+    push_alpha,
+    push_string
+);
 benchmark_main!(benches);

--- a/benches/extend.rs
+++ b/benches/extend.rs
@@ -1,13 +1,13 @@
-
 extern crate arrayvec;
-#[macro_use] extern crate bencher;
+#[macro_use]
+extern crate bencher;
 
 use std::io::Write;
 
 use arrayvec::ArrayVec;
 
-use bencher::Bencher;
 use bencher::black_box;
+use bencher::Bencher;
 
 fn extend_with_constant(b: &mut Bencher) {
     let mut v = ArrayVec::<u8, 512>::new();
@@ -67,12 +67,13 @@ fn extend_from_slice(b: &mut Bencher) {
     b.bytes = v.capacity() as u64;
 }
 
-benchmark_group!(benches,
-                 extend_with_constant,
-                 extend_with_range,
-                 extend_with_slice,
-                 extend_with_write,
-                 extend_from_slice
+benchmark_group!(
+    benches,
+    extend_with_constant,
+    extend_with_range,
+    extend_with_slice,
+    extend_with_write,
+    extend_from_slice
 );
 
 benchmark_main!(benches);

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -11,14 +11,13 @@ use std::str;
 use std::str::FromStr;
 use std::str::Utf8Error;
 
-use crate::CapacityError;
-use crate::LenUint;
 use crate::char::encode_utf8;
 use crate::utils::MakeMaybeUninit;
+use crate::CapacityError;
+use crate::LenUint;
 
-#[cfg(feature="serde")]
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
-
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A string with a fixed capacity.
 ///
@@ -37,16 +36,14 @@ pub struct ArrayString<const CAP: usize> {
     len: LenUint,
 }
 
-impl<const CAP: usize> Default for ArrayString<CAP>
-{
+impl<const CAP: usize> Default for ArrayString<CAP> {
     /// Return an empty `ArrayString`
     fn default() -> ArrayString<CAP> {
         ArrayString::new()
     }
 }
 
-impl<const CAP: usize> ArrayString<CAP>
-{
+impl<const CAP: usize> ArrayString<CAP> {
     /// Create a new empty `ArrayString`.
     ///
     /// Capacity is inferred from the type parameter.
@@ -62,7 +59,10 @@ impl<const CAP: usize> ArrayString<CAP>
     pub fn new() -> ArrayString<CAP> {
         assert_capacity_limit!(CAP);
         unsafe {
-            ArrayString { xs: MaybeUninit::uninit().assume_init(), len: 0 }
+            ArrayString {
+                xs: MaybeUninit::uninit().assume_init(),
+                len: 0,
+            }
         }
     }
 
@@ -77,16 +77,23 @@ impl<const CAP: usize> ArrayString<CAP>
     /// ```
     pub const fn new_const() -> ArrayString<CAP> {
         assert_capacity_limit_const!(CAP);
-        ArrayString { xs: MakeMaybeUninit::ARRAY, len: 0 }
+        ArrayString {
+            xs: MakeMaybeUninit::ARRAY,
+            len: 0,
+        }
     }
 
     /// Return the length of the string.
     #[inline]
-    pub const fn len(&self) -> usize { self.len as usize }
+    pub const fn len(&self) -> usize {
+        self.len as usize
+    }
 
     /// Returns whether the string is empty.
     #[inline]
-    pub const fn is_empty(&self) -> bool { self.len() == 0 }
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Create a new `ArrayString` from a `str`.
     ///
@@ -146,7 +153,7 @@ impl<const CAP: usize> ArrayString<CAP>
         unsafe {
             ArrayString {
                 xs: MaybeUninit::zeroed().assume_init(),
-                len: CAP as _
+                len: CAP as _,
             }
         }
     }
@@ -160,7 +167,9 @@ impl<const CAP: usize> ArrayString<CAP>
     /// assert_eq!(string.capacity(), 3);
     /// ```
     #[inline(always)]
-    pub const fn capacity(&self) -> usize { CAP }
+    pub const fn capacity(&self) -> usize {
+        CAP
+    }
 
     /// Return if the `ArrayString` is completely filled.
     ///
@@ -172,7 +181,9 @@ impl<const CAP: usize> ArrayString<CAP>
     /// string.push_str("A");
     /// assert!(string.is_full());
     /// ```
-    pub const fn is_full(&self) -> bool { self.len() == self.capacity() }
+    pub const fn is_full(&self) -> bool {
+        self.len() == self.capacity()
+    }
 
     /// Returns the capacity left in the `ArrayString`.
     ///
@@ -296,7 +307,7 @@ impl<const CAP: usize> ArrayString<CAP>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<3>::from("foo").unwrap();
     ///
     /// assert_eq!(s.pop(), Some('o'));
@@ -336,7 +347,7 @@ impl<const CAP: usize> ArrayString<CAP>
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
             assert!(self.is_char_boundary(new_len));
-            unsafe { 
+            unsafe {
                 // In libstd truncate is called on the underlying vector,
                 // which in turns drops each element.
                 // As we know we don't have to worry about Drop,
@@ -356,7 +367,7 @@ impl<const CAP: usize> ArrayString<CAP>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<3>::from("foo").unwrap();
     ///
     /// assert_eq!(s.remove(0), 'f');
@@ -373,10 +384,7 @@ impl<const CAP: usize> ArrayString<CAP>
         let len = self.len();
         let ptr = self.as_mut_ptr();
         unsafe {
-            ptr::copy(
-                ptr.add(next),
-                ptr.add(idx),
-                len - next);
+            ptr::copy(ptr.add(next), ptr.add(idx), len - next);
             self.set_len(len - (next - idx));
         }
         ch
@@ -421,8 +429,7 @@ impl<const CAP: usize> ArrayString<CAP>
     }
 }
 
-impl<const CAP: usize> Deref for ArrayString<CAP>
-{
+impl<const CAP: usize> Deref for ArrayString<CAP> {
     type Target = str;
     #[inline]
     fn deref(&self) -> &str {
@@ -433,8 +440,7 @@ impl<const CAP: usize> Deref for ArrayString<CAP>
     }
 }
 
-impl<const CAP: usize> DerefMut for ArrayString<CAP>
-{
+impl<const CAP: usize> DerefMut for ArrayString<CAP> {
     #[inline]
     fn deref_mut(&mut self) -> &mut str {
         unsafe {
@@ -445,65 +451,64 @@ impl<const CAP: usize> DerefMut for ArrayString<CAP>
     }
 }
 
-impl<const CAP: usize> PartialEq for ArrayString<CAP>
-{
+impl<const CAP: usize> PartialEq for ArrayString<CAP> {
     fn eq(&self, rhs: &Self) -> bool {
         **self == **rhs
     }
 }
 
-impl<const CAP: usize> PartialEq<str> for ArrayString<CAP>
-{
+impl<const CAP: usize> PartialEq<str> for ArrayString<CAP> {
     fn eq(&self, rhs: &str) -> bool {
         &**self == rhs
     }
 }
 
-impl<const CAP: usize> PartialEq<ArrayString<CAP>> for str
-{
+impl<const CAP: usize> PartialEq<ArrayString<CAP>> for str {
     fn eq(&self, rhs: &ArrayString<CAP>) -> bool {
         self == &**rhs
     }
 }
 
-impl<const CAP: usize> Eq for ArrayString<CAP> 
-{ }
+impl<const CAP: usize> Eq for ArrayString<CAP> {}
 
-impl<const CAP: usize> Hash for ArrayString<CAP>
-{
+impl<const CAP: usize> Hash for ArrayString<CAP> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         (**self).hash(h)
     }
 }
 
-impl<const CAP: usize> Borrow<str> for ArrayString<CAP>
-{
-    fn borrow(&self) -> &str { self }
+impl<const CAP: usize> Borrow<str> for ArrayString<CAP> {
+    fn borrow(&self) -> &str {
+        self
+    }
 }
 
-impl<const CAP: usize> BorrowMut<str> for ArrayString<CAP>
-{
-    fn borrow_mut(&mut self) -> &mut str { self }
+impl<const CAP: usize> BorrowMut<str> for ArrayString<CAP> {
+    fn borrow_mut(&mut self) -> &mut str {
+        self
+    }
 }
 
-impl<const CAP: usize> AsRef<str> for ArrayString<CAP>
-{
-    fn as_ref(&self) -> &str { self }
+impl<const CAP: usize> AsRef<str> for ArrayString<CAP> {
+    fn as_ref(&self) -> &str {
+        self
+    }
 }
 
-impl<const CAP: usize> fmt::Debug for ArrayString<CAP>
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { (**self).fmt(f) }
+impl<const CAP: usize> fmt::Debug for ArrayString<CAP> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
-impl<const CAP: usize> fmt::Display for ArrayString<CAP>
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { (**self).fmt(f) }
+impl<const CAP: usize> fmt::Display for ArrayString<CAP> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
 /// `Write` appends written data to the end of the string.
-impl<const CAP: usize> fmt::Write for ArrayString<CAP>
-{
+impl<const CAP: usize> fmt::Write for ArrayString<CAP> {
     fn write_char(&mut self, c: char) -> fmt::Result {
         self.try_push(c).map_err(|_| fmt::Error)
     }
@@ -513,8 +518,7 @@ impl<const CAP: usize> fmt::Write for ArrayString<CAP>
     }
 }
 
-impl<const CAP: usize> Clone for ArrayString<CAP>
-{
+impl<const CAP: usize> Clone for ArrayString<CAP> {
     fn clone(&self) -> ArrayString<CAP> {
         *self
     }
@@ -525,8 +529,8 @@ impl<const CAP: usize> Clone for ArrayString<CAP>
     }
 }
 
-impl<const CAP: usize> PartialOrd for ArrayString<CAP>
-{
+#[cfg_attr(rustfmt, rustfmt::skip)]
+impl<const CAP: usize> PartialOrd for ArrayString<CAP> {
     fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
         (**self).partial_cmp(&**rhs)
     }
@@ -536,8 +540,8 @@ impl<const CAP: usize> PartialOrd for ArrayString<CAP>
     fn ge(&self, rhs: &Self) -> bool { **self >= **rhs }
 }
 
-impl<const CAP: usize> PartialOrd<str> for ArrayString<CAP>
-{
+#[cfg_attr(rustfmt, rustfmt::skip)]
+impl<const CAP: usize> PartialOrd<str> for ArrayString<CAP> {
     fn partial_cmp(&self, rhs: &str) -> Option<cmp::Ordering> {
         (**self).partial_cmp(rhs)
     }
@@ -547,8 +551,8 @@ impl<const CAP: usize> PartialOrd<str> for ArrayString<CAP>
     fn ge(&self, rhs: &str) -> bool { &**self >= rhs }
 }
 
-impl<const CAP: usize> PartialOrd<ArrayString<CAP>> for str
-{
+#[cfg_attr(rustfmt, rustfmt::skip)]
+impl<const CAP: usize> PartialOrd<ArrayString<CAP>> for str {
     fn partial_cmp(&self, rhs: &ArrayString<CAP>) -> Option<cmp::Ordering> {
         self.partial_cmp(&**rhs)
     }
@@ -558,15 +562,13 @@ impl<const CAP: usize> PartialOrd<ArrayString<CAP>> for str
     fn ge(&self, rhs: &ArrayString<CAP>) -> bool { self >= &**rhs }
 }
 
-impl<const CAP: usize> Ord for ArrayString<CAP>
-{
+impl<const CAP: usize> Ord for ArrayString<CAP> {
     fn cmp(&self, rhs: &Self) -> cmp::Ordering {
         (**self).cmp(&**rhs)
     }
 }
 
-impl<const CAP: usize> FromStr for ArrayString<CAP>
-{
+impl<const CAP: usize> FromStr for ArrayString<CAP> {
     type Err = CapacityError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -574,23 +576,23 @@ impl<const CAP: usize> FromStr for ArrayString<CAP>
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
-impl<const CAP: usize> Serialize for ArrayString<CAP>
-{
+impl<const CAP: usize> Serialize for ArrayString<CAP> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&*self)
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 /// Requires crate feature `"serde"`
-impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP> 
-{
+impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         use serde::de::{self, Visitor};
         use std::marker::PhantomData;
@@ -605,15 +607,18 @@ impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP>
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where E: de::Error,
+            where
+                E: de::Error,
             {
                 ArrayString::from(v).map_err(|_| E::invalid_length(v.len(), &self))
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                where E: de::Error,
+            where
+                E: de::Error,
             {
-                let s = str::from_utf8(v).map_err(|_| E::invalid_value(de::Unexpected::Bytes(v), &self))?;
+                let s = str::from_utf8(v)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Bytes(v), &self))?;
 
                 ArrayString::from(s).map_err(|_| E::invalid_length(s.len(), &self))
             }
@@ -623,8 +628,7 @@ impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP>
     }
 }
 
-impl<'a, const CAP: usize> TryFrom<&'a str> for ArrayString<CAP>
-{
+impl<'a, const CAP: usize> TryFrom<&'a str> for ArrayString<CAP> {
     type Error = CapacityError<&'a str>;
 
     fn try_from(f: &'a str) -> Result<Self, Self::Error> {
@@ -634,8 +638,7 @@ impl<'a, const CAP: usize> TryFrom<&'a str> for ArrayString<CAP>
     }
 }
 
-impl<'a, const CAP: usize> TryFrom<fmt::Arguments<'a>> for ArrayString<CAP>
-{
+impl<'a, const CAP: usize> TryFrom<fmt::Arguments<'a>> for ArrayString<CAP> {
     type Error = CapacityError<fmt::Error>;
 
     fn try_from(f: fmt::Arguments<'a>) -> Result<Self, Self::Error> {

--- a/src/arrayvec_impl.rs
+++ b/src/arrayvec_impl.rs
@@ -16,17 +16,13 @@ pub(crate) trait ArrayVecImpl {
     /// Return a slice containing all elements of the vector.
     fn as_slice(&self) -> &[Self::Item] {
         let len = self.len();
-        unsafe {
-            slice::from_raw_parts(self.as_ptr(), len)
-        }
+        unsafe { slice::from_raw_parts(self.as_ptr(), len) }
     }
 
     /// Return a mutable slice containing all elements of the vector.
     fn as_mut_slice(&mut self) -> &mut [Self::Item] {
         let len = self.len();
-        unsafe {
-            std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
-        }
+        unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 
     /// Return a raw pointer to the vector's buffer.
@@ -83,4 +79,3 @@ pub(crate) trait ArrayVecImpl {
         }
     }
 }
-

--- a/src/char.rs
+++ b/src/char.rs
@@ -11,13 +11,14 @@
 // Original authors: alexchrichton, bluss
 
 // UTF-8 ranges and tags for encoding characters
-const TAG_CONT: u8    = 0b1000_0000;
-const TAG_TWO_B: u8   = 0b1100_0000;
+const TAG_CONT: u8 = 0b1000_0000;
+const TAG_TWO_B: u8 = 0b1100_0000;
 const TAG_THREE_B: u8 = 0b1110_0000;
-const TAG_FOUR_B: u8  = 0b1111_0000;
-const MAX_ONE_B: u32   =     0x80;
-const MAX_TWO_B: u32   =    0x800;
-const MAX_THREE_B: u32 =  0x10000;
+const TAG_FOUR_B: u8 = 0b1111_0000;
+
+const MAX_ONE_B: u32 = 0x80;
+const MAX_TWO_B: u32 = 0x800;
+const MAX_THREE_B: u32 = 0x10000;
 
 /// Placeholder
 pub struct EncodeUtf8Error;
@@ -28,9 +29,9 @@ pub struct EncodeUtf8Error;
 /// On error, return `EncodeUtf8Error` if the buffer was too short for the char.
 ///
 /// Safety: `ptr` must be writable for `len` bytes.
+#[cfg_attr(rustfmt, rustfmt::skip)]
 #[inline]
-pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, EncodeUtf8Error>
-{
+pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, EncodeUtf8Error> {
     let code = ch as u32;
     if code < MAX_ONE_B && len >= 1 {
         ptr.add(0).write(code as u8);
@@ -54,7 +55,6 @@ pub unsafe fn encode_utf8(ch: char, ptr: *mut u8, len: usize) -> Result<usize, E
     Err(EncodeUtf8Error)
 }
 
-
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_encode_utf8() {
@@ -62,7 +62,9 @@ fn test_encode_utf8() {
     let mut data = [0u8; 16];
     for codepoint in 0..=(std::char::MAX as u32) {
         if let Some(ch) = std::char::from_u32(codepoint) {
-            for elt in &mut data { *elt = 0; }
+            for elt in &mut data {
+                *elt = 0;
+            }
             let ptr = data.as_mut_ptr();
             let len = data.len();
             unsafe {
@@ -89,4 +91,3 @@ fn test_encode_utf8_oob() {
         }
     }
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
-use std::fmt;
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::any::Any;
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::error::Error;
+use std::fmt;
 
 /// Error value indicating insufficient capacity
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
@@ -13,9 +13,7 @@ pub struct CapacityError<T = ()> {
 impl<T> CapacityError<T> {
     /// Create a new `CapacityError` from `element`.
     pub const fn new(element: T) -> CapacityError<T> {
-        CapacityError {
-            element: element,
-        }
+        CapacityError { element: element }
     }
 
     /// Extract the overflowing element
@@ -31,7 +29,7 @@ impl<T> CapacityError<T> {
 
 const CAPERROR: &'static str = "insufficient capacity";
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 /// Requires `features="std"`.
 impl<T: Any> Error for CapacityError<T> {}
 
@@ -46,4 +44,3 @@ impl<T> fmt::Debug for CapacityError<T> {
         write!(f, "{}: {}", "CapacityError", CAPERROR)
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]: 
+//! **arrayvec** provides the types [`ArrayVec`] and [`ArrayString`]:
 //! array-backed vector and string types, which store their contents inline.
 //!
 //! The arrayvec package has the following cargo features:
@@ -15,13 +15,13 @@
 //!
 //! This version of arrayvec requires Rust 1.51 or later.
 //!
-#![doc(html_root_url="https://docs.rs/arrayvec/0.7/")]
-#![cfg_attr(not(feature="std"), no_std)]
+#![doc(html_root_url = "https://docs.rs/arrayvec/0.7/")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 extern crate core as std;
 
 pub(crate) type LenUint = u32;
@@ -33,7 +33,7 @@ macro_rules! assert_capacity_limit {
                 panic!("ArrayVec: largest supported capacity is u32::MAX")
             }
         }
-    }
+    };
 }
 
 macro_rules! assert_capacity_limit_const {
@@ -46,9 +46,9 @@ macro_rules! assert_capacity_limit_const {
     }
 }
 
-mod arrayvec_impl;
-mod arrayvec;
 mod array_string;
+mod arrayvec;
+mod arrayvec_impl;
 mod char;
 mod errors;
 mod utils;
@@ -56,4 +56,4 @@ mod utils;
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
 
-pub use crate::arrayvec::{ArrayVec, IntoIter, Drain};
+pub use crate::arrayvec::{ArrayVec, Drain, IntoIter};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,4 +8,3 @@ impl<T, const N: usize> MakeMaybeUninit<T, N> {
 
     pub(crate) const ARRAY: [MaybeUninit<T>; N] = [Self::VALUE; N];
 }
-

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -5,18 +5,14 @@ extern crate serde_test;
 mod array_vec {
     use arrayvec::ArrayVec;
 
-    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
     #[test]
     fn test_ser_de_empty() {
         let vec = ArrayVec::<u32, 0>::new();
 
-        assert_tokens(&vec, &[
-            Token::Seq { len: Some(0) },
-            Token::SeqEnd,
-        ]);
+        assert_tokens(&vec, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
     }
-
 
     #[test]
     fn test_ser_de() {
@@ -25,55 +21,57 @@ mod array_vec {
         vec.push(55);
         vec.push(123);
 
-        assert_tokens(&vec, &[
-            Token::Seq { len: Some(3) },
-            Token::U32(20),
-            Token::U32(55),
-            Token::U32(123),
-            Token::SeqEnd,
-        ]);
+        assert_tokens(
+            &vec,
+            &[
+                Token::Seq { len: Some(3) },
+                Token::U32(20),
+                Token::U32(55),
+                Token::U32(123),
+                Token::SeqEnd,
+            ],
+        );
     }
 
     #[test]
     fn test_de_too_large() {
-        assert_de_tokens_error::<ArrayVec<u32, 2>>(&[
-            Token::Seq { len: Some(3) },
-            Token::U32(13),
-            Token::U32(42),
-            Token::U32(68),
-        ], "invalid length 3, expected an array with no more than 2 items");
+        assert_de_tokens_error::<ArrayVec<u32, 2>>(
+            &[
+                Token::Seq { len: Some(3) },
+                Token::U32(13),
+                Token::U32(42),
+                Token::U32(68),
+            ],
+            "invalid length 3, expected an array with no more than 2 items",
+        );
     }
 }
 
 mod array_string {
     use arrayvec::ArrayString;
 
-    use serde_test::{Token, assert_tokens, assert_de_tokens_error};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
 
     #[test]
     fn test_ser_de_empty() {
         let string = ArrayString::<0>::new();
 
-        assert_tokens(&string, &[
-            Token::Str(""),
-        ]);
+        assert_tokens(&string, &[Token::Str("")]);
     }
-
 
     #[test]
     fn test_ser_de() {
         let string = ArrayString::<9>::from("1234 abcd")
             .expect("expected exact specified capacity to be enough");
 
-        assert_tokens(&string, &[
-            Token::Str("1234 abcd"),
-        ]);
+        assert_tokens(&string, &[Token::Str("1234 abcd")]);
     }
 
     #[test]
     fn test_de_too_large() {
-        assert_de_tokens_error::<ArrayString<2>>(&[
-            Token::Str("afd")
-        ], "invalid length 3, expected a string no more than 2 bytes long");
+        assert_de_tokens_error::<ArrayString<2>>(
+            &[Token::Str("afd")],
+            "invalid length 3, expected a string no more than 2 bytes long",
+        );
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,19 +1,19 @@
 extern crate arrayvec;
-#[macro_use] extern crate matches;
+#[macro_use]
+extern crate matches;
 
-use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
-use std::mem;
+use arrayvec::ArrayVec;
 use arrayvec::CapacityError;
+use std::mem;
 
 use std::collections::HashMap;
-
 
 #[test]
 fn test_simple() {
     use std::ops::Add;
 
-    let mut vec: ArrayVec<Vec<i32>,  3> = ArrayVec::new();
+    let mut vec: ArrayVec<Vec<i32>, 3> = ArrayVec::new();
 
     vec.push(vec![1, 2, 3, 4]);
     vec.push(vec![10]);
@@ -29,7 +29,7 @@ fn test_simple() {
 
 #[test]
 fn test_capacity_left() {
-    let mut vec: ArrayVec<usize,  4> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 4> = ArrayVec::new();
     assert_eq!(vec.remaining_capacity(), 4);
     vec.push(1);
     assert_eq!(vec.remaining_capacity(), 3);
@@ -43,7 +43,7 @@ fn test_capacity_left() {
 
 #[test]
 fn test_extend_from_slice() {
-    let mut vec: ArrayVec<usize,  10> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 10> = ArrayVec::new();
 
     vec.try_extend_from_slice(&[1, 2, 3]).unwrap();
     assert_eq!(vec.len(), 3);
@@ -54,13 +54,13 @@ fn test_extend_from_slice() {
 
 #[test]
 fn test_extend_from_slice_error() {
-    let mut vec: ArrayVec<usize,  10> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 10> = ArrayVec::new();
 
     vec.try_extend_from_slice(&[1, 2, 3]).unwrap();
     let res = vec.try_extend_from_slice(&[0; 8]);
     assert_matches!(res, Err(_));
 
-    let mut vec: ArrayVec<usize,  0> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 0> = ArrayVec::new();
     let res = vec.try_extend_from_slice(&[0; 1]);
     assert_matches!(res, Err(_));
 }
@@ -70,14 +70,14 @@ fn test_try_from_slice_error() {
     use arrayvec::ArrayVec;
     use std::convert::TryInto as _;
 
-    let res: Result<ArrayVec<_,  2>, _> = (&[1, 2, 3] as &[_]).try_into();
+    let res: Result<ArrayVec<_, 2>, _> = (&[1, 2, 3] as &[_]).try_into();
     assert_matches!(res, Err(_));
 }
 
 #[test]
 fn test_u16_index() {
     const N: usize = 4096;
-    let mut vec: ArrayVec<_,  N> = ArrayVec::new();
+    let mut vec: ArrayVec<_, N> = ArrayVec::new();
     for _ in 0..N {
         assert!(vec.try_push(1u8).is_ok());
     }
@@ -113,7 +113,7 @@ fn test_drop() {
     }
 
     {
-        let mut array = ArrayVec::<Bump,  128>::new();
+        let mut array = ArrayVec::<Bump, 128>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
     }
@@ -123,7 +123,7 @@ fn test_drop() {
     flag.set(0);
 
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(vec![Bump(flag)]);
         array.push(vec![Bump(flag), Bump(flag)]);
         array.push(vec![]);
@@ -142,7 +142,7 @@ fn test_drop() {
     // test into_inner
     flag.set(0);
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -156,7 +156,7 @@ fn test_drop() {
     // test take
     flag.set(0);
     {
-        let mut array1 = ArrayVec::<_,  3>::new();
+        let mut array1 = ArrayVec::<_, 3>::new();
         array1.push(Bump(flag));
         array1.push(Bump(flag));
         array1.push(Bump(flag));
@@ -171,7 +171,7 @@ fn test_drop() {
     // test cloning into_iter
     flag.set(0);
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -225,7 +225,7 @@ fn test_drop_panics() {
 
     flag.set(0);
     {
-        let mut array = ArrayVec::<Bump,  128>::new();
+        let mut array = ArrayVec::<Bump, 128>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -238,10 +238,9 @@ fn test_drop_panics() {
     // Check that all the elements drop, even if the first drop panics.
     assert_eq!(flag.get(), 3);
 
-
     flag.set(0);
     {
-        let mut array = ArrayVec::<Bump,  16>::new();
+        let mut array = ArrayVec::<Bump, 16>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -258,22 +257,20 @@ fn test_drop_panics() {
         // Check that all the tail elements drop, even if the first drop panics.
         assert_eq!(flag.get(), tail_len as i32);
     }
-
-
 }
 
 #[test]
 fn test_extend() {
     let mut range = 0..10;
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).collect();
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
     assert_eq!(range.next(), Some(5));
 
     array.extend(range.by_ref().take(0));
     assert_eq!(range.next(), Some(6));
 
-    let mut array: ArrayVec<_,  10> = (0..3).collect();
+    let mut array: ArrayVec<_, 10> = (0..3).collect();
     assert_eq!(&array[..], &[0, 1, 2]);
     array.extend(3..5);
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
@@ -284,7 +281,7 @@ fn test_extend() {
 fn test_extend_capacity_panic_1() {
     let mut range = 0..10;
 
-    let _: ArrayVec<_,  5> = range.by_ref().collect();
+    let _: ArrayVec<_, 5> = range.by_ref().collect();
 }
 
 #[should_panic]
@@ -292,7 +289,7 @@ fn test_extend_capacity_panic_1() {
 fn test_extend_capacity_panic_2() {
     let mut range = 0..10;
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).collect();
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
     assert_eq!(range.next(), Some(5));
     array.extend(range.by_ref().take(1));
@@ -300,7 +297,7 @@ fn test_extend_capacity_panic_2() {
 
 #[test]
 fn test_is_send_sync() {
-    let data = ArrayVec::<Vec<i32>,  5>::new();
+    let data = ArrayVec::<Vec<i32>, 5>::new();
     &data as &dyn Send;
     &data as &dyn Sync;
 }
@@ -308,24 +305,24 @@ fn test_is_send_sync() {
 #[test]
 fn test_compact_size() {
     // 4 bytes + padding + length
-    type ByteArray = ArrayVec<u8,  4>;
+    type ByteArray = ArrayVec<u8, 4>;
     println!("{}", mem::size_of::<ByteArray>());
     assert!(mem::size_of::<ByteArray>() <= 2 * mem::size_of::<u32>());
 
     // just length
-    type EmptyArray = ArrayVec<u8,  0>;
+    type EmptyArray = ArrayVec<u8, 0>;
     println!("{}", mem::size_of::<EmptyArray>());
     assert!(mem::size_of::<EmptyArray>() <= mem::size_of::<u32>());
 
     // 3 elements + padding + length
-    type QuadArray = ArrayVec<u32,  3>;
+    type QuadArray = ArrayVec<u32, 3>;
     println!("{}", mem::size_of::<QuadArray>());
     assert!(mem::size_of::<QuadArray>() <= 4 * 4 + mem::size_of::<u32>());
 }
 
 #[test]
 fn test_still_works_with_option_arrayvec() {
-    type RefArray = ArrayVec<&'static i32,  2>;
+    type RefArray = ArrayVec<&'static i32, 2>;
     let array = Some(RefArray::new());
     assert!(array.is_some());
     println!("{:?}", array);
@@ -341,7 +338,7 @@ fn test_drain() {
     v.extend(0..8);
     v.drain(1..4);
     assert_eq!(&v[..], &[0, 4, 5, 6, 7]);
-    let u: ArrayVec<_,  3> = v.drain(1..4).rev().collect();
+    let u: ArrayVec<_, 3> = v.drain(1..4).rev().collect();
     assert_eq!(&u[..], &[6, 5, 4]);
     assert_eq!(&v[..], &[0, 7]);
     v.drain(..);
@@ -357,7 +354,7 @@ fn test_drain_range_inclusive() {
     v.extend(0..8);
     v.drain(1..=4);
     assert_eq!(&v[..], &[0, 5, 6, 7]);
-    let u: ArrayVec<_,  3> = v.drain(1..=2).rev().collect();
+    let u: ArrayVec<_, 3> = v.drain(1..=2).rev().collect();
     assert_eq!(&u[..], &[6, 5]);
     assert_eq!(&v[..], &[0, 7]);
     v.drain(..);
@@ -407,7 +404,7 @@ fn test_drop_panic() {
         }
     }
 
-    let mut array = ArrayVec::<DropPanic,  1>::new();
+    let mut array = ArrayVec::<DropPanic, 1>::new();
     array.push(DropPanic);
 }
 
@@ -422,7 +419,7 @@ fn test_drop_panic_into_iter() {
         }
     }
 
-    let mut array = ArrayVec::<DropPanic,  1>::new();
+    let mut array = ArrayVec::<DropPanic, 1>::new();
     array.push(DropPanic);
     array.into_iter();
 }
@@ -432,7 +429,7 @@ fn test_insert() {
     let mut v = ArrayVec::from([]);
     assert_matches!(v.try_push(1), Err(_));
 
-    let mut v = ArrayVec::<_,  3>::new();
+    let mut v = ArrayVec::<_, 3>::new();
     v.insert(0, 0);
     v.insert(1, 1);
     //let ret1 = v.try_insert(3, 3);
@@ -461,7 +458,7 @@ fn test_into_inner_1() {
 
 #[test]
 fn test_into_inner_2() {
-    let mut v = ArrayVec::<String,  4>::new();
+    let mut v = ArrayVec::<String, 4>::new();
     v.push("a".into());
     v.push("b".into());
     v.push("c".into());
@@ -471,25 +468,25 @@ fn test_into_inner_2() {
 
 #[test]
 fn test_into_inner_3() {
-    let mut v = ArrayVec::<i32,  4>::new();
+    let mut v = ArrayVec::<i32, 4>::new();
     v.extend(1..=4);
     assert_eq!(v.into_inner().unwrap(), [1, 2, 3, 4]);
 }
 
 #[test]
 fn test_take() {
-    let mut v1 = ArrayVec::<i32,  4>::new();
+    let mut v1 = ArrayVec::<i32, 4>::new();
     v1.extend(1..=4);
     let v2 = v1.take();
     assert!(v1.into_inner().is_err());
     assert_eq!(v2.into_inner().unwrap(), [1, 2, 3, 4]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_write() {
     use std::io::Write;
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     write!(&mut v, "\x01\x02\x03").unwrap();
     assert_eq!(&v[..], &[1, 2, 3]);
     let r = v.write(&[9; 16]).unwrap();
@@ -499,16 +496,16 @@ fn test_write() {
 
 #[test]
 fn array_clone_from() {
-    let mut v = ArrayVec::<_,  4>::new();
+    let mut v = ArrayVec::<_, 4>::new();
     v.push(vec![1, 2]);
     v.push(vec![3, 4, 5]);
     v.push(vec![6]);
     let reference = v.to_vec();
-    let mut u = ArrayVec::<_,  4>::new();
+    let mut u = ArrayVec::<_, 4>::new();
     u.clone_from(&v);
     assert_eq!(&u, &reference[..]);
 
-    let mut t = ArrayVec::<_,  4>::new();
+    let mut t = ArrayVec::<_, 4>::new();
     t.push(vec![97]);
     t.push(vec![]);
     t.push(vec![5, 6, 2]);
@@ -520,7 +517,7 @@ fn array_clone_from() {
     assert_eq!(&t, &reference[..]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_string() {
     use std::error::Error;
@@ -557,7 +554,7 @@ fn test_string() {
 #[test]
 fn test_string_from() {
     let text = "hello world";
-	// Test `from` constructor
+    // Test `from` constructor
     let u = ArrayString::<11>::from(text).unwrap();
     assert_eq!(&u, text);
     assert_eq!(u.len(), text.len());
@@ -604,10 +601,9 @@ fn test_string_push() {
     assert!(s.try_push('x').is_err());
 }
 
-
 #[test]
 fn test_insert_at_length() {
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     let result1 = v.try_insert(0, "a");
     let result2 = v.try_insert(1, "b");
     assert!(result1.is_ok() && result2.is_ok());
@@ -617,7 +613,7 @@ fn test_insert_at_length() {
 #[should_panic]
 #[test]
 fn test_insert_out_of_bounds() {
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     let _ = v.try_insert(1, "test");
 }
 
@@ -650,7 +646,7 @@ fn test_drop_in_insert() {
     flag.set(0);
 
     {
-        let mut array = ArrayVec::<_,  2>::new();
+        let mut array = ArrayVec::<_, 2>::new();
         array.push(Bump(flag));
         array.insert(0, Bump(flag));
         assert_eq!(flag.get(), 0);
@@ -665,7 +661,7 @@ fn test_drop_in_insert() {
 
 #[test]
 fn test_pop_at() {
-    let mut v = ArrayVec::<String,  4>::new();
+    let mut v = ArrayVec::<String, 4>::new();
     let s = String::from;
     v.push(s("a"));
     v.push(s("b"));
@@ -690,19 +686,19 @@ fn test_default() {
     use std::net;
     let s: ArrayString<4> = Default::default();
     // Something without `Default` implementation.
-    let v: ArrayVec<net::TcpStream,  4> = Default::default();
+    let v: ArrayVec<net::TcpStream, 4> = Default::default();
     assert_eq!(s.len(), 0);
     assert_eq!(v.len(), 0);
 }
 
-#[cfg(feature="array-sizes-33-128")]
+#[cfg(feature = "array-sizes-33-128")]
 #[test]
 fn test_sizes_33_128() {
     ArrayVec::from([0u8; 52]);
     ArrayVec::from([0u8; 127]);
 }
 
-#[cfg(feature="array-sizes-129-255")]
+#[cfg(feature = "array-sizes-129-255")]
 #[test]
 fn test_sizes_129_255() {
     ArrayVec::from([0u8; 237]);
@@ -715,14 +711,14 @@ fn test_extend_zst() {
     #[derive(Copy, Clone, PartialEq, Debug)]
     struct Z; // Zero sized type
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).map(|_| Z).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).map(|_| Z).collect();
     assert_eq!(&array[..], &[Z; 5]);
     assert_eq!(range.next(), Some(5));
 
     array.extend(range.by_ref().take(0).map(|_| Z));
     assert_eq!(range.next(), Some(6));
 
-    let mut array: ArrayVec<_,  10> = (0..3).map(|_| Z).collect();
+    let mut array: ArrayVec<_, 10> = (0..3).map(|_| Z).collect();
     assert_eq!(&array[..], &[Z; 3]);
     array.extend((3..5).map(|_| Z));
     assert_eq!(&array[..], &[Z; 5]);
@@ -739,27 +735,27 @@ fn test_try_from_argument() {
 #[test]
 fn allow_max_capacity_arrayvec_type() {
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}>;
+    let _v: ArrayVec<(), { usize::MAX }>;
 }
 
-#[should_panic(expected="largest supported capacity")]
+#[should_panic(expected = "largest supported capacity")]
 #[test]
 fn deny_max_capacity_arrayvec_value() {
     if mem::size_of::<usize>() <= mem::size_of::<u32>() {
         panic!("This test does not work on this platform. 'largest supported capacity'");
     }
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new();
+    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new();
 }
 
-#[should_panic(expected="index out of bounds")]
+#[should_panic(expected = "index out of bounds")]
 #[test]
 fn deny_max_capacity_arrayvec_value_const() {
     if mem::size_of::<usize>() <= mem::size_of::<u32>() {
         panic!("This test does not work on this platform. 'index out of bounds'");
     }
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new_const();
+    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new_const();
 }
 
 #[test]
@@ -783,7 +779,6 @@ fn test_arraystring_const_constructible() {
     var.push_str("hello");
     assert_eq!(var, *"hello");
 }
-
 
 #[test]
 fn test_arraystring_zero_filled_has_some_sanity_checks() {


### PR DESCRIPTION
# Motivation
- Following rustfmt generally increases willingness in contributing to the project.
- Removing cogitive overhead in reviewing potentially important PR #222.

Seems like a few of your personal preferences like single-line methods _could_ be accomplished by requiring nightly rustfmt but I suspect you'd see lots of those get reverted in PRs by folks who automatically apply stable rustfmt in their editor.