### PR TITLE
Add Natvis visualizations for ArrayVec and ArrayString types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         include:
           - rust: 1.51.0 # MSRV
             features: serde
@@ -29,6 +29,12 @@ jobs:
           - rust: nightly
             features: serde
             experimental: false
+          - rust: nightly
+            features: debugger_visualizer
+            os: windows-latest
+            experimental: false
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -43,6 +49,9 @@ jobs:
           cargo doc --verbose --features "${{ matrix.features }}" --no-deps
           cargo test --verbose --features "${{ matrix.features }}"
           cargo test --release --verbose --features "${{ matrix.features }}"
+      - name: Test debugger visualizer
+        if: matrix.features == 'debugger_visualizer'
+        run: cargo test --release --verbose --features "${{ matrix.features }}" --test debugger_visualizer -- --test-threads=1
       - name: Test run benchmarks
         if: matrix.bench != ''
         run: cargo test -v --benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ version = "1.0"
 [dev-dependencies]
 matches = { version = "0.1" }
 bencher = "0.1.4"
+debugger_test = "0.1"
+debugger_test_parser = "0.1"
 
 [[bench]]
 name = "extend"
@@ -34,9 +36,24 @@ harness = false
 name = "arraystring"
 harness = false
 
+[[test]]
+name = "debugger_visualizer"
+path = "tests/debugger_visualizer.rs"
+required-features = ["debugger_visualizer"]
+# Do not run these tests by default. These tests need to
+# be run with the additional rustc flag `--test-threads=1`
+# since each test causes a debugger to attach to the current
+# test process. If multiple debuggers try to attach at the same
+# time, the test will fail.
+test = false
+
 [features]
 default = ["std"]
 std = []
+
+# UNSTABLE FEATURES (requires Rust nightly)
+# Enable to use the #[debugger_visualizer] attribute.
+debugger_visualizer = []
 
 [profile.bench]
 debug = true

--- a/debug_metadata/arrayvec.natvis
+++ b/debug_metadata/arrayvec.natvis
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="arrayvec::array_string::ArrayString&lt;*&gt;">
+    <DisplayString>{xs,[len]s8}</DisplayString>
+    <StringView>{xs,[len]s8}</StringView>
+    <Expand>
+      <Item Name="[len]" ExcludeView="simple">len</Item>
+      <Item Name="[capacity]" ExcludeView="simple">$T1</Item>
+      <CustomListItems>
+        <Variable Name="i" InitialValue="0" />
+        <Size>len</Size>
+        <Loop>
+          <Item>(char)xs[i].value.value</Item>
+          <Exec>i++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="arrayvec::arrayvec::ArrayVec&lt;*,*&gt;">
+    <DisplayString>{{ len={len} }}</DisplayString>
+    <Expand>
+      <Item Name="[len]" ExcludeView="simple">len</Item>
+      <Item Name="[capacity]" ExcludeView="simple">$T2</Item>
+      <CustomListItems>
+        <Variable Name="i" InitialValue="0" />
+        <Size>len</Size>
+        <Loop>
+          <Item>($T1)xs[i].value.value</Item>
+          <Exec>i++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,11 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.7/")]
 #![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(
+    feature="debugger_visualizer",
+    feature(debugger_visualizer),
+    debugger_visualizer(natvis_file = "../debug_metadata/arrayvec.natvis")
+)]
 
 #[cfg(feature="serde")]
 extern crate serde;

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -1,0 +1,82 @@
+use arrayvec::ArrayString;
+use arrayvec::ArrayVec;
+use debugger_test::debugger_test;
+
+#[inline(never)]
+fn __break() {
+    println!("Breakpoint hit");
+}
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = r#"
+.nvlist
+dv
+
+dx array
+dx string
+
+g
+
+dx string
+"#,
+    expected_statements = r#"
+array            : { len=0xa } [Type: arrayvec::arrayvec::ArrayVec<i32,10>]
+    [<Raw View>]     [Type: arrayvec::arrayvec::ArrayVec<i32,10>]
+    [len]            : 0xa [Type: unsigned int]
+    [capacity]       : 10
+    [0x0]            : 1 [Type: i32]
+    [0x1]            : 2 [Type: i32]
+    [0x2]            : 3 [Type: i32]
+    [0x3]            : 4 [Type: i32]
+    [0x4]            : 5 [Type: i32]
+    [0x5]            : 6 [Type: i32]
+    [0x6]            : 7 [Type: i32]
+    [0x7]            : 8 [Type: i32]
+    [0x8]            : 9 [Type: i32]
+    [0x9]            : 10 [Type: i32]
+
+string           : "foo" [Type: arrayvec::array_string::ArrayString<10>]
+    [<Raw View>]     [Type: arrayvec::array_string::ArrayString<10>]
+    [len]            : 0x3 [Type: unsigned int]
+    [capacity]       : 10
+    [0x0]            : 102 'f' [Type: char]
+    [0x1]            : 111 'o' [Type: char]
+    [0x2]            : 111 'o' [Type: char]
+
+string           : "foo-bar" [Type: arrayvec::array_string::ArrayString<10>]
+    [<Raw View>]     [Type: arrayvec::array_string::ArrayString<10>]
+    [len]            : 0x7 [Type: unsigned int]
+    [capacity]       : 10
+    [0x0]            : 102 'f' [Type: char]
+    [0x1]            : 111 'o' [Type: char]
+    [0x2]            : 111 'o' [Type: char]
+    [0x3]            : 45 '-' [Type: char]
+    [0x4]            : 98 'b' [Type: char]
+    [0x5]            : 97 'a' [Type: char]
+    [0x6]            : 114 'r' [Type: char]
+"#
+)]
+#[inline(never)]
+fn test_debugger_visualizer() {
+    let mut array = ArrayVec::<i32, 10>::new();
+    for i in 0..10 {
+        array.push(i + 1);
+    }
+    assert_eq!(&array[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert_eq!(array.capacity(), 10);
+
+    let mut string = ArrayString::<10>::new();
+    string.push_str("foo");
+    assert_eq!(&string[..], "foo");
+    assert_eq!(string.capacity(), 10);
+    __break();
+
+    string.push_str("-bar");
+    assert_eq!(&string[..], "foo-bar");
+    assert_eq!(string.capacity(), 10);
+
+    let result = string.to_string();
+    assert_eq!(String::from("foo-bar"), result);
+    __break();
+}


### PR DESCRIPTION
This change adds Natvis visualizations for ArrayVec and ArrayString to help improve the debugging experience on Windows.

Natvis is a framework that can be used to specify how types should be viewed under a supported debugger, such as the Windows debugger (WinDbg) and the Visual Studio debugger.

When debugging types such as ArrayVec and/or ArrayString under a Windows debugger, the entries for these data structures are not always clear upon first glance. The internal data structure is shown, and it's not presented in a user-friendly way. The Rust compiler does have Natvis support for some types, but this is limited to some of the core libraries and not supported for external crates.

https://github.com/rust-lang/rfcs/pull/3191 proposes adding support for embedding debugging visualizations such as Natvis in a Rust crate. This RFC has been approved, merged and implemented.

This PR adds:

Natvis visualizations for both ArrayVec and ArrayString.
Tests for testing visualizers embedded in the `arrayvec` crate.
Updates to the CI pipeline to ensure tests for visualizers are run so they do not break silently.
A new debugger_visualizer feature for the `arrayvec` crate to enable the unstable debugger_visualizer Rust feature.