### PR TITLE
add const function to get &str from ArrayString

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -296,7 +296,7 @@ impl<const CAP: usize> ArrayString<CAP>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<3>::from("foo").unwrap();
     ///
     /// assert_eq!(s.pop(), Some('o'));
@@ -336,7 +336,7 @@ impl<const CAP: usize> ArrayString<CAP>
     pub fn truncate(&mut self, new_len: usize) {
         if new_len <= self.len() {
             assert!(self.is_char_boundary(new_len));
-            unsafe { 
+            unsafe {
                 // In libstd truncate is called on the underlying vector,
                 // which in turns drops each element.
                 // As we know we don't have to worry about Drop,
@@ -356,7 +356,7 @@ impl<const CAP: usize> ArrayString<CAP>
     ///
     /// ```
     /// use arrayvec::ArrayString;
-    /// 
+    ///
     /// let mut s = ArrayString::<3>::from("foo").unwrap();
     ///
     /// assert_eq!(s.remove(0), 'f');
@@ -412,12 +412,22 @@ impl<const CAP: usize> ArrayString<CAP>
         self
     }
 
-    fn as_ptr(&self) -> *const u8 {
+    const fn as_ptr(&self) -> *const u8 {
         self.xs.as_ptr() as *const u8
     }
 
     fn as_mut_ptr(&mut self) -> *mut u8 {
         self.xs.as_mut_ptr() as *mut u8
+    }
+
+    /// Provide a &str in constant contexts where the dereference
+    /// trait is not available.
+    #[inline]
+    pub const fn as_str_const(&self) -> &str {
+        unsafe {
+            let sl = slice::from_raw_parts(self.as_ptr(), self.len());
+            str::from_utf8_unchecked(sl)
+        }
     }
 }
 
@@ -466,7 +476,7 @@ impl<const CAP: usize> PartialEq<ArrayString<CAP>> for str
     }
 }
 
-impl<const CAP: usize> Eq for ArrayString<CAP> 
+impl<const CAP: usize> Eq for ArrayString<CAP>
 { }
 
 impl<const CAP: usize> Hash for ArrayString<CAP>
@@ -587,7 +597,7 @@ impl<const CAP: usize> Serialize for ArrayString<CAP>
 
 #[cfg(feature="serde")]
 /// Requires crate feature `"serde"`
-impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP> 
+impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -545,7 +545,13 @@ fn test_string() {
     let tmut: &mut str = &mut t;
     assert_eq!(tmut, "ab");
 
+    // test ArrayString -> &str in const
+    const CONST_T: ArrayString<2> = ArrayString::<2>::new_const();
+    const CONST_S: &str = CONST_T.as_str_const();
+    assert_eq!(CONST_S, "");
+
     // Test Error trait / try
+
     let t = || -> Result<(), Box<dyn Error>> {
         let mut t = ArrayString::<2>::new();
         t.try_push_str(text)?;


### PR DESCRIPTION
👋 Hello @bluss! Thank you for making this crate; it's super useful.

I don't think we can dereference an ArrayString into a &str in a constant function right now, and the Deref trait is unlikely to become const in the near future. Do you have an idea of the best way to support ArrayString -> string coercion? 

One way would just be to add a new function into ArrayString. I've done that in this PR in case it would be helpful; otherwise, let me know if you prefer me to open an issue for this.