### PR TITLE
Add convenience constructor for null-terminated byte literals

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -129,6 +129,23 @@ impl<const CAP: usize> ArrayString<CAP>
         Ok(vec)
     }
 
+    /// Create a new `ArrayString` from a byte string literal, that can be null-terminated.
+    ///
+    /// **Errors** if the byte string literal is not valid UTF-8.
+    /// ```
+    /// use arrayvec::ArrayString;
+    ///
+    /// let string = ArrayString::from_c_byte_string(b"hello\0world").unwrap();
+    /// assert_eq!(&string,"hello")
+    /// ```
+    pub fn from_c_byte_string(b: &[u8; CAP]) -> Result<Self, Utf8Error> {
+        let mut result = Self::from_byte_string(b)?;
+        if let Some(i) = &result.find('\0') {
+            result.truncate(*i);
+        }
+        Ok(result)
+    }
+
     /// Create a new `ArrayString` value fully filled with ASCII NULL characters (`\0`). Useful
     /// to be used as a buffer to collect external data or as a buffer for intermediate processing.
     ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -580,6 +580,14 @@ fn test_string_from_bytes() {
 }
 
 #[test]
+fn test_string_from_c_bytes() {
+    let text = "hello";
+    let u = ArrayString::from_c_byte_string(b"hello\0world").unwrap();
+    assert_eq!(&u, text);
+    assert_eq!(u.len(), text.len());
+}
+
+#[test]
 fn test_string_clone() {
     let text = "hi";
     let mut s = ArrayString::<4>::new();


### PR DESCRIPTION
This adds a small convenience function for making ArrayStrings out of null-terminated C-style byte buffers, by truncating the result to first null-terminator, if present.

Of course this a pretty trivial utility to keep as a free-standing function in code that needs to deal with C input, so maybe not a great fit here.