### PR TITLE
Use 16-bit lengths on 16-bit targets

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -25,8 +25,8 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// The `ArrayString` is a string backed by a fixed size array. It keeps track
 /// of its length, and is parameterized by `CAP` for the maximum capacity.
 ///
-/// `CAP` is of type `usize` but is range limited to `u32::MAX`; attempting to create larger
-/// arrayvecs with larger capacity will panic.
+/// `CAP` is of type `usize` but is range limited to `u32::MAX` (or `u16` on 16-bit targets);
+/// attempting to create larger arrayvecs with larger capacity will panic.
 ///
 /// The string is a contiguous value that you can store directly on the stack
 /// if needed.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -31,8 +31,8 @@ use crate::utils::MakeMaybeUninit;
 /// the number of initialized elements. The `ArrayVec<T, CAP>` is parameterized
 /// by `T` for the element type and `CAP` for the maximum capacity.
 ///
-/// `CAP` is of type `usize` but is range limited to `u32::MAX`; attempting to create larger
-/// arrayvecs with larger capacity will panic.
+/// `CAP` is of type `usize` but is range limited to `u32::MAX` (or `u16::MAX` on 16-bit targets);
+/// attempting to create larger arrayvecs with larger capacity will panic.
 ///
 /// The vector is a contiguous value (storing the elements inline) that you can store directly on
 /// the stack if needed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,20 @@ extern crate serde;
 #[cfg(not(feature="std"))]
 extern crate core as std;
 
+#[cfg(not(target_pointer_width = "16"))]
 pub(crate) type LenUint = u32;
+
+#[cfg(target_pointer_width = "16")]
+pub(crate) type LenUint = u16;
 
 macro_rules! assert_capacity_limit {
     ($cap:expr) => {
         if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
             if $cap > LenUint::MAX as usize {
-                panic!("ArrayVec: largest supported capacity is u32::MAX")
+                #[cfg(not(target_pointer_width = "16"))]
+                panic!("ArrayVec: largest supported capacity is u32::MAX");
+                #[cfg(target_pointer_width = "16")]
+                panic!("ArrayVec: largest supported capacity is u16::MAX");
             }
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -680,6 +680,7 @@ fn test_pop_at() {
 }
 
 #[test]
+#[cfg(not(target_pointer_width = "16"))]
 fn test_sizes() {
     let v = ArrayVec::from([0u8; 1 << 16]);
     assert_eq!(vec![0u8; v.len()], &v[..]);
@@ -743,21 +744,17 @@ fn allow_max_capacity_arrayvec_type() {
 }
 
 #[should_panic(expected="largest supported capacity")]
+#[cfg(not(target_pointer_width = "16"))]
 #[test]
 fn deny_max_capacity_arrayvec_value() {
-    if mem::size_of::<usize>() <= mem::size_of::<u32>() {
-        panic!("This test does not work on this platform. 'largest supported capacity'");
-    }
     // this type is allowed to be used (but can't be constructed)
     let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new();
 }
 
 #[should_panic(expected="index out of bounds")]
+#[cfg(not(target_pointer_width = "16"))]
 #[test]
 fn deny_max_capacity_arrayvec_value_const() {
-    if mem::size_of::<usize>() <= mem::size_of::<u32>() {
-        panic!("This test does not work on this platform. 'index out of bounds'");
-    }
     // this type is allowed to be used (but can't be constructed)
     let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new_const();
 }


### PR DESCRIPTION
This changes the internal length type from `u32` to `u16` on 16-bit targets. On 16-bit targets larger arrays won't be used, 32-bit arithmetic can be expensive, and 4 bytes is a significant overhead.

`target_pointer_width` is not going to be smaller than "16", so `#[cfg(not(target_pointer_width = "16"))]` is sufficient to mean > 16.

Rustup doesn't ship a 16-bit target by default, so unfortunately it's not easy to add a compile test for it, but the tests pass with `u16` `LenUint` on larger platforms.