### PR TITLE
Optionally implement Zeroize on ArrayVec/ArrayString

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,13 @@ jobs:
             experimental: false
           - rust: stable
             features:
+            bench: true
             experimental: false
           - rust: beta
             features: serde
             experimental: false
           - rust: nightly
-            features: serde
+            features: serde, zeroize
             experimental: false
 
     steps:
@@ -57,4 +58,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ version = "1.0"
 optional = true
 default-features = false
 
+[dependencies.zeroize]
+version = "1.4"
+optional = true
+default-features = false
+
 [dev-dependencies.serde_test]
 version = "1.0"
 


### PR DESCRIPTION
This will be very useful as `ArrayVec` is used in cryptographic libraries so the user might want to zero out the content (See https://github.com/BLAKE3-team/BLAKE3/pull/309)

P.S. I'm not sure about the use of `unsafe` in the test examples, I can split them into unit tests if wanted.