### PR TITLE
MAINT: Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,10 @@ jobs:
             experimental: false
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Tests
         run: |
           cargo build --verbose --features "${{ matrix.features }}"
@@ -51,7 +49,7 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/bluss/arrayvec/actions/runs/5299901385:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.