### PR TITLE
Add len_u16 and len_u8 features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ harness = false
 [features]
 default = ["std"]
 std = []
+len_u16 = []
+len_u8 = []
 
 [profile.bench]
 debug = true

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -25,8 +25,9 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// The `ArrayString` is a string backed by a fixed size array. It keeps track
 /// of its length, and is parameterized by `CAP` for the maximum capacity.
 ///
-/// `CAP` is of type `usize` but is range limited to `u32::MAX`; attempting to create larger
-/// arrayvecs with larger capacity will panic.
+/// The length is stored in `u32` by default, and can be changed to `u16` or `u8`
+/// by `len_u16` or `len_u8` feature. Attempting to create arrayvecs with larger
+/// capacity will panic.
 ///
 /// The string is a contiguous value that you can store directly on the stack
 /// if needed.
@@ -73,7 +74,7 @@ impl<const CAP: usize> ArrayString<CAP>
     /// ```
     /// use arrayvec::ArrayString;
     ///
-    /// static ARRAY: ArrayString<1024> = ArrayString::new_const();
+    /// static ARRAY: ArrayString<255> = ArrayString::new_const();
     /// ```
     pub const fn new_const() -> ArrayString<CAP> {
         assert_capacity_limit_const!(CAP);

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -31,8 +31,9 @@ use crate::utils::MakeMaybeUninit;
 /// the number of initialized elements. The `ArrayVec<T, CAP>` is parameterized
 /// by `T` for the element type and `CAP` for the maximum capacity.
 ///
-/// `CAP` is of type `usize` but is range limited to `u32::MAX`; attempting to create larger
-/// arrayvecs with larger capacity will panic.
+/// The length is stored in `u32` by default, and can be changed to `u16` or `u8`
+/// by `len_u16` or `len_u8` feature. Attempting to create arrayvecs with larger
+/// capacity will panic.
 ///
 /// The vector is a contiguous value (storing the elements inline) that you can store directly on
 /// the stack if needed.
@@ -93,7 +94,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// ```
     /// use arrayvec::ArrayVec;
     ///
-    /// static ARRAY: ArrayVec<u8, 1024> = ArrayVec::new_const();
+    /// static ARRAY: ArrayVec<u8, 255> = ArrayVec::new_const();
     /// ```
     pub const fn new_const() -> ArrayVec<T, CAP> {
         assert_capacity_limit_const!(CAP);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,14 @@
 //!   - Optional, enabled by default
 //!   - Use libstd; disable to use `no_std` instead.
 //!
+//! - `len_u16`
+//!   - Optional.
+//!   - Use `u16` as length type.
+//!
+//! - `len_u8`
+//!   - Optional.
+//!   - Use `u8` as length type.
+//!
 //! - `serde`
 //!   - Optional
 //!   - Enable serialization for ArrayVec and ArrayString using serde 1.x
@@ -28,13 +36,20 @@ extern crate serde;
 #[cfg(not(feature="std"))]
 extern crate core as std;
 
+#[cfg(all(not(feature="len_u8"), not(feature="len_u16")))]
 pub(crate) type LenUint = u32;
+
+#[cfg(feature="len_u16")]
+pub(crate) type LenUint = u16;
+
+#[cfg(feature="len_u8")]
+pub(crate) type LenUint = u8;
 
 macro_rules! assert_capacity_limit {
     ($cap:expr) => {
         if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
             if $cap > LenUint::MAX as usize {
-                panic!("ArrayVec: largest supported capacity is u32::MAX")
+                panic!("ArrayVec: largest supported capacity is {}", LenUint::MAX)
             }
         }
     }
@@ -44,7 +59,7 @@ macro_rules! assert_capacity_limit_const {
     ($cap:expr) => {
         if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
             if $cap > LenUint::MAX as usize {
-                [/*ArrayVec: largest supported capacity is u32::MAX*/][$cap]
+                [/*ArrayVec: largest supported capacity is LenUint::MAX*/][$cap]
             }
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -75,6 +75,7 @@ fn test_try_from_slice_error() {
 }
 
 #[test]
+#[cfg(feature="array-len-u16")]
 fn test_u16_index() {
     const N: usize = 4096;
     let mut vec: ArrayVec<_,  N> = ArrayVec::new();
@@ -681,7 +682,7 @@ fn test_pop_at() {
 
 #[test]
 fn test_sizes() {
-    let v = ArrayVec::from([0u8; 1 << 16]);
+    let v = ArrayVec::from([0u8; 255]);
     assert_eq!(vec![0u8; v.len()], &v[..]);
 }
 


### PR DESCRIPTION
Add `len_u16` and `len_u8` features to change the type of `LenUint`.

Using `u8` as `LenUint` saves 3 bytes. This is useful for many really small strings.