### PR TITLE
Implement `serde_with::SerializeAs` and `serde_with ::DeserializeAs` for `ArrayVec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ version = "1.0"
 optional = true
 default-features = false
 
+[dependencies.serde_with]
+version = "3"
+optional = true
+default-features = false
+
 [dependencies.zeroize]
 version = "1.4"
 optional = true
@@ -30,6 +35,7 @@ version = "1.0"
 [dev-dependencies]
 matches = { version = "0.1" }
 bencher = "0.1.4"
+serde_with = { version = "3" }
 
 [[bench]]
 name = "extend"
@@ -42,6 +48,7 @@ harness = false
 [features]
 default = ["std"]
 std = []
+serde = ["dep:serde", "dep:serde_with"]
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
`serde_with` is a widely used crate (24M downloads) to allow custom (de)serialisation.

This commit allow to use Arrayvec as a container in the `serde_with::serde_as` macro.

```rust
#[serde_as]
#[derive(Serialize, Deserialize)]
pub struct Native {
    #[serde_as(as = "ArrayVec<DisplayFromStr,128>")]
    pub sans: ArrayVec<TypeWithoutSerde, 128>,
}
```

I've it included under the `serde` feature, but it can be on its own feature.

If this is deemed to niche to include, an alternative would be to include it directly in the `serde_with` crate under a feature flag, similar to what is done for other popular library, such as `hashbrown_0_14` or `chrono_0_4`. It has the disadvantage of pinning to one version.