### PR TITLE
Make length type generic

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -31,10 +31,11 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// The string is a contiguous value that you can store directly on the stack
 /// if needed.
 #[derive(Copy)]
+#[repr(C)]
 pub struct ArrayString<const CAP: usize> {
     // the `len` first elements of the array are initialized
-    xs: [MaybeUninit<u8>; CAP],
     len: LenUint,
+    xs: [MaybeUninit<u8>; CAP],
 }
 
 impl<const CAP: usize> Default for ArrayString<CAP>

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -39,10 +39,11 @@ use crate::utils::MakeMaybeUninit;
 ///
 /// It offers a simple API but also dereferences to a slice, so that the full slice API is
 /// available. The ArrayVec can be converted into a by value iterator.
+#[repr(C)]
 pub struct ArrayVec<T, const CAP: usize> {
+    len: LenUint,
     // the `len` first elements of the array are initialized
     xs: [MaybeUninit<T>; CAP],
-    len: LenUint,
 }
 
 impl<T, const CAP: usize> Drop for ArrayVec<T, CAP> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,28 +28,48 @@ extern crate serde;
 #[cfg(not(feature="std"))]
 extern crate core as std;
 
-pub(crate) type LenUint = u32;
-
+pub trait LenUint: Add + Sub + Copy + PartialOrd + PartialEq + private::Sealed  {
+    const MAX: usize;
+    const ZERO: Self;
+    fn from_usize(n: usize) -> Self;
+    fn to_usize(self) -> usize;
+}
+macro_rules! impl_lenuint {
+    ($ty: path) => {
+        impl $crate::private::Sealed for $ty {}
+        impl $crate::LenUint for $ty {
+            const MAX: usize = <$ty>::MAX as usize;
+            const ZERO: Self = 0;
+            fn from_usize(n: usize) -> Self { n as $ty }
+            fn to_usize(self) -> usize { self as usize }
+        }
+    };
+}
+mod private {
+    pub trait Sealed {}
+    impl_lenuint!(u8);
+    impl_lenuint!(u16);
+    impl_lenuint!(u32);
+    #[cfg(target_pointer_width = "64")]
+    impl_lenuint!(u64);
+    impl_lenuint!(usize);
+}
 macro_rules! assert_capacity_limit {
-    ($cap:expr) => {
-        if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
-            if $cap > LenUint::MAX as usize {
-                panic!("ArrayVec: largest supported capacity is u32::MAX")
-            }
+    ($ty: path, $cap:expr) => {
+        if $cap > <$ty as LenUint>::MAX {
+            panic!("ArrayVec: capacity {} is too large for {}::MAX={}", CAP, std::any::type_name::<$ty>(), <$ty as LenUint>::MAX)
         }
     }
 }
 
 macro_rules! assert_capacity_limit_const {
-    ($cap:expr) => {
-        if std::mem::size_of::<usize>() > std::mem::size_of::<LenUint>() {
-            if $cap > LenUint::MAX as usize {
-                [/*ArrayVec: largest supported capacity is u32::MAX*/][$cap]
-            }
+    ($ty: path, $cap:expr) => {
+        if $cap > <$ty as LenUint>::MAX {
+            panic!("ArrayVec: capacity is too large for LenUint::MAX")
         }
     }
 }
-
+pub type DefaultLenUint = u32;
 mod arrayvec_impl;
 mod arrayvec;
 mod array_string;
@@ -57,6 +77,8 @@ mod char;
 mod errors;
 mod utils;
 
+use core::ops::Sub;
+use std::ops::Add;
 pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,4 +8,3 @@ impl<T, const N: usize> MakeMaybeUninit<T, N> {
 
     pub(crate) const ARRAY: [MaybeUninit<T>; N] = [Self::VALUE; N];
 }
-

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 extern crate arrayvec;
-#[macro_use] extern crate matches;
+#[macro_use]
+extern crate matches;
 
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
@@ -13,7 +14,7 @@ use std::collections::HashMap;
 fn test_simple() {
     use std::ops::Add;
 
-    let mut vec: ArrayVec<Vec<i32>,  3> = ArrayVec::new();
+    let mut vec: ArrayVec<Vec<i32>, 3> = ArrayVec::new();
 
     vec.push(vec![1, 2, 3, 4]);
     vec.push(vec![10]);
@@ -29,7 +30,7 @@ fn test_simple() {
 
 #[test]
 fn test_capacity_left() {
-    let mut vec: ArrayVec<usize,  4> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 4> = ArrayVec::new();
     assert_eq!(vec.remaining_capacity(), 4);
     vec.push(1);
     assert_eq!(vec.remaining_capacity(), 3);
@@ -43,7 +44,7 @@ fn test_capacity_left() {
 
 #[test]
 fn test_extend_from_slice() {
-    let mut vec: ArrayVec<usize,  10> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 10> = ArrayVec::new();
 
     vec.try_extend_from_slice(&[1, 2, 3]).unwrap();
     assert_eq!(vec.len(), 3);
@@ -54,13 +55,13 @@ fn test_extend_from_slice() {
 
 #[test]
 fn test_extend_from_slice_error() {
-    let mut vec: ArrayVec<usize,  10> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 10> = ArrayVec::new();
 
     vec.try_extend_from_slice(&[1, 2, 3]).unwrap();
     let res = vec.try_extend_from_slice(&[0; 8]);
     assert_matches!(res, Err(_));
 
-    let mut vec: ArrayVec<usize,  0> = ArrayVec::new();
+    let mut vec: ArrayVec<usize, 0> = ArrayVec::new();
     let res = vec.try_extend_from_slice(&[0; 1]);
     assert_matches!(res, Err(_));
 }
@@ -70,14 +71,14 @@ fn test_try_from_slice_error() {
     use arrayvec::ArrayVec;
     use std::convert::TryInto as _;
 
-    let res: Result<ArrayVec<_,  2>, _> = (&[1, 2, 3] as &[_]).try_into();
+    let res: Result<ArrayVec<_, 2>, _> = (&[1, 2, 3] as &[_]).try_into();
     assert_matches!(res, Err(_));
 }
 
 #[test]
 fn test_u16_index() {
     const N: usize = 4096;
-    let mut vec: ArrayVec<_,  N> = ArrayVec::new();
+    let mut vec: ArrayVec<_, N> = ArrayVec::new();
     for _ in 0..N {
         assert!(vec.try_push(1u8).is_ok());
     }
@@ -87,7 +88,8 @@ fn test_u16_index() {
 
 #[test]
 fn test_iter() {
-    let mut iter = ArrayVec::from([1, 2, 3]).into_iter();
+    let vec: ArrayVec<_, 3> = ArrayVec::from([1, 2, 3]);
+    let mut iter = vec.into_iter();
     assert_eq!(iter.size_hint(), (3, Some(3)));
     assert_eq!(iter.next_back(), Some(3));
     assert_eq!(iter.next(), Some(1));
@@ -113,7 +115,7 @@ fn test_drop() {
     }
 
     {
-        let mut array = ArrayVec::<Bump,  128>::new();
+        let mut array = ArrayVec::<Bump, 128>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
     }
@@ -123,7 +125,7 @@ fn test_drop() {
     flag.set(0);
 
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(vec![Bump(flag)]);
         array.push(vec![Bump(flag), Bump(flag)]);
         array.push(vec![]);
@@ -142,7 +144,7 @@ fn test_drop() {
     // test into_inner
     flag.set(0);
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -156,7 +158,7 @@ fn test_drop() {
     // test take
     flag.set(0);
     {
-        let mut array1 = ArrayVec::<_,  3>::new();
+        let mut array1 = ArrayVec::<_, 3>::new();
         array1.push(Bump(flag));
         array1.push(Bump(flag));
         array1.push(Bump(flag));
@@ -171,7 +173,7 @@ fn test_drop() {
     // test cloning into_iter
     flag.set(0);
     {
-        let mut array = ArrayVec::<_,  3>::new();
+        let mut array = ArrayVec::<_, 3>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -225,7 +227,7 @@ fn test_drop_panics() {
 
     flag.set(0);
     {
-        let mut array = ArrayVec::<Bump,  128>::new();
+        let mut array = ArrayVec::<Bump, 128>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -241,7 +243,7 @@ fn test_drop_panics() {
 
     flag.set(0);
     {
-        let mut array = ArrayVec::<Bump,  16>::new();
+        let mut array = ArrayVec::<Bump, 16>::new();
         array.push(Bump(flag));
         array.push(Bump(flag));
         array.push(Bump(flag));
@@ -258,22 +260,20 @@ fn test_drop_panics() {
         // Check that all the tail elements drop, even if the first drop panics.
         assert_eq!(flag.get(), tail_len as i32);
     }
-
-
 }
 
 #[test]
 fn test_extend() {
     let mut range = 0..10;
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).collect();
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
     assert_eq!(range.next(), Some(5));
 
     array.extend(range.by_ref().take(0));
     assert_eq!(range.next(), Some(6));
 
-    let mut array: ArrayVec<_,  10> = (0..3).collect();
+    let mut array: ArrayVec<_, 10> = (0..3).collect();
     assert_eq!(&array[..], &[0, 1, 2]);
     array.extend(3..5);
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
@@ -284,7 +284,7 @@ fn test_extend() {
 fn test_extend_capacity_panic_1() {
     let mut range = 0..10;
 
-    let _: ArrayVec<_,  5> = range.by_ref().collect();
+    let _: ArrayVec<_, 5> = range.by_ref().collect();
 }
 
 #[should_panic]
@@ -292,7 +292,7 @@ fn test_extend_capacity_panic_1() {
 fn test_extend_capacity_panic_2() {
     let mut range = 0..10;
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).collect();
     assert_eq!(&array[..], &[0, 1, 2, 3, 4]);
     assert_eq!(range.next(), Some(5));
     array.extend(range.by_ref().take(1));
@@ -300,7 +300,7 @@ fn test_extend_capacity_panic_2() {
 
 #[test]
 fn test_is_send_sync() {
-    let data = ArrayVec::<Vec<i32>,  5>::new();
+    let data = ArrayVec::<Vec<i32>, 5>::new();
     &data as &dyn Send;
     &data as &dyn Sync;
 }
@@ -308,24 +308,24 @@ fn test_is_send_sync() {
 #[test]
 fn test_compact_size() {
     // 4 bytes + padding + length
-    type ByteArray = ArrayVec<u8,  4>;
+    type ByteArray = ArrayVec<u8, 4>;
     println!("{}", mem::size_of::<ByteArray>());
     assert!(mem::size_of::<ByteArray>() <= 2 * mem::size_of::<u32>());
 
     // just length
-    type EmptyArray = ArrayVec<u8,  0>;
+    type EmptyArray = ArrayVec<u8, 0>;
     println!("{}", mem::size_of::<EmptyArray>());
     assert!(mem::size_of::<EmptyArray>() <= mem::size_of::<u32>());
 
     // 3 elements + padding + length
-    type QuadArray = ArrayVec<u32,  3>;
+    type QuadArray = ArrayVec<u32, 3>;
     println!("{}", mem::size_of::<QuadArray>());
     assert!(mem::size_of::<QuadArray>() <= 4 * 4 + mem::size_of::<u32>());
 }
 
 #[test]
 fn test_still_works_with_option_arrayvec() {
-    type RefArray = ArrayVec<&'static i32,  2>;
+    type RefArray = ArrayVec<&'static i32, 2>;
     let array = Some(RefArray::new());
     assert!(array.is_some());
     println!("{:?}", array);
@@ -333,7 +333,7 @@ fn test_still_works_with_option_arrayvec() {
 
 #[test]
 fn test_drain() {
-    let mut v = ArrayVec::from([0; 8]);
+    let mut v: ArrayVec<i32, 8> = ArrayVec::from([0; 8]);
     v.pop();
     v.drain(0..7);
     assert_eq!(&v[..], &[]);
@@ -341,7 +341,7 @@ fn test_drain() {
     v.extend(0..8);
     v.drain(1..4);
     assert_eq!(&v[..], &[0, 4, 5, 6, 7]);
-    let u: ArrayVec<_,  3> = v.drain(1..4).rev().collect();
+    let u: ArrayVec<_, 3> = v.drain(1..4).rev().collect();
     assert_eq!(&u[..], &[6, 5, 4]);
     assert_eq!(&v[..], &[0, 7]);
     v.drain(..);
@@ -350,14 +350,14 @@ fn test_drain() {
 
 #[test]
 fn test_drain_range_inclusive() {
-    let mut v = ArrayVec::from([0; 8]);
+    let mut v: ArrayVec<_, 8> = ArrayVec::from([0; 8]);
     v.drain(0..=7);
     assert_eq!(&v[..], &[]);
 
     v.extend(0..8);
     v.drain(1..=4);
     assert_eq!(&v[..], &[0, 5, 6, 7]);
-    let u: ArrayVec<_,  3> = v.drain(1..=2).rev().collect();
+    let u: ArrayVec<_, 3> = v.drain(1..=2).rev().collect();
     assert_eq!(&u[..], &[6, 5]);
     assert_eq!(&v[..], &[0, 7]);
     v.drain(..);
@@ -367,13 +367,13 @@ fn test_drain_range_inclusive() {
 #[test]
 #[should_panic]
 fn test_drain_range_inclusive_oob() {
-    let mut v = ArrayVec::from([0; 0]);
+    let mut v: ArrayVec<_, 0> = ArrayVec::from([0; 0]);
     v.drain(0..=0);
 }
 
 #[test]
 fn test_retain() {
-    let mut v = ArrayVec::from([0; 8]);
+    let mut v: ArrayVec<_, 8> = ArrayVec::from([0; 8]);
     for (i, elt) in v.iter_mut().enumerate() {
         *elt = i;
     }
@@ -391,7 +391,7 @@ fn test_retain() {
 #[test]
 #[should_panic]
 fn test_drain_oob() {
-    let mut v = ArrayVec::from([0; 8]);
+    let mut v: ArrayVec<_, 8> = ArrayVec::from([0; 8]);
     v.pop();
     v.drain(0..8);
 }
@@ -407,7 +407,7 @@ fn test_drop_panic() {
         }
     }
 
-    let mut array = ArrayVec::<DropPanic,  1>::new();
+    let mut array = ArrayVec::<DropPanic, 1>::new();
     array.push(DropPanic);
 }
 
@@ -422,17 +422,17 @@ fn test_drop_panic_into_iter() {
         }
     }
 
-    let mut array = ArrayVec::<DropPanic,  1>::new();
+    let mut array = ArrayVec::<DropPanic, 1>::new();
     array.push(DropPanic);
     array.into_iter();
 }
 
 #[test]
 fn test_insert() {
-    let mut v = ArrayVec::from([]);
+    let mut v: ArrayVec<_, 0> = ArrayVec::from([]);
     assert_matches!(v.try_push(1), Err(_));
 
-    let mut v = ArrayVec::<_,  3>::new();
+    let mut v = ArrayVec::<_, 3>::new();
     v.insert(0, 0);
     v.insert(1, 1);
     //let ret1 = v.try_insert(3, 3);
@@ -445,7 +445,7 @@ fn test_insert() {
     assert_eq!(&v[..], &[0, 1, 2]);
     assert_matches!(ret2, Err(_));
 
-    let mut v = ArrayVec::from([2]);
+    let mut v: ArrayVec<_, 1> = ArrayVec::from([2]);
     assert_matches!(v.try_insert(0, 1), Err(CapacityError { .. }));
     assert_matches!(v.try_insert(1, 1), Err(CapacityError { .. }));
     //assert_matches!(v.try_insert(2, 1), Err(CapacityError { .. }));
@@ -453,7 +453,7 @@ fn test_insert() {
 
 #[test]
 fn test_into_inner_1() {
-    let mut v = ArrayVec::from([1, 2]);
+    let mut v: ArrayVec<_, 2> = ArrayVec::from([1, 2]);
     v.pop();
     let u = v.clone();
     assert_eq!(v.into_inner(), Err(u));
@@ -461,7 +461,7 @@ fn test_into_inner_1() {
 
 #[test]
 fn test_into_inner_2() {
-    let mut v = ArrayVec::<String,  4>::new();
+    let mut v = ArrayVec::<String, 4>::new();
     v.push("a".into());
     v.push("b".into());
     v.push("c".into());
@@ -471,25 +471,25 @@ fn test_into_inner_2() {
 
 #[test]
 fn test_into_inner_3() {
-    let mut v = ArrayVec::<i32,  4>::new();
+    let mut v = ArrayVec::<i32, 4>::new();
     v.extend(1..=4);
     assert_eq!(v.into_inner().unwrap(), [1, 2, 3, 4]);
 }
 
 #[test]
 fn test_take() {
-    let mut v1 = ArrayVec::<i32,  4>::new();
+    let mut v1 = ArrayVec::<i32, 4>::new();
     v1.extend(1..=4);
     let v2 = v1.take();
     assert!(v1.into_inner().is_err());
     assert_eq!(v2.into_inner().unwrap(), [1, 2, 3, 4]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_write() {
     use std::io::Write;
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     write!(&mut v, "\x01\x02\x03").unwrap();
     assert_eq!(&v[..], &[1, 2, 3]);
     let r = v.write(&[9; 16]).unwrap();
@@ -499,16 +499,16 @@ fn test_write() {
 
 #[test]
 fn array_clone_from() {
-    let mut v = ArrayVec::<_,  4>::new();
+    let mut v = ArrayVec::<_, 4>::new();
     v.push(vec![1, 2]);
     v.push(vec![3, 4, 5]);
     v.push(vec![6]);
     let reference = v.to_vec();
-    let mut u = ArrayVec::<_,  4>::new();
+    let mut u = ArrayVec::<_, 4>::new();
     u.clone_from(&v);
     assert_eq!(&u, &reference[..]);
 
-    let mut t = ArrayVec::<_,  4>::new();
+    let mut t = ArrayVec::<_, 4>::new();
     t.push(vec![97]);
     t.push(vec![]);
     t.push(vec![5, 6, 2]);
@@ -520,7 +520,7 @@ fn array_clone_from() {
     assert_eq!(&t, &reference[..]);
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 #[test]
 fn test_string() {
     use std::error::Error;
@@ -557,7 +557,7 @@ fn test_string() {
 #[test]
 fn test_string_from() {
     let text = "hello world";
-	// Test `from` constructor
+    // Test `from` constructor
     let u = ArrayString::<11>::from(text).unwrap();
     assert_eq!(&u, text);
     assert_eq!(u.len(), text.len());
@@ -574,7 +574,7 @@ fn test_string_parse_from_str() {
 #[test]
 fn test_string_from_bytes() {
     let text = "hello world";
-    let u = ArrayString::from_byte_string(b"hello world").unwrap();
+    let u: ArrayString<11> = ArrayString::from_byte_string(b"hello world").unwrap();
     assert_eq!(&u, text);
     assert_eq!(u.len(), text.len());
 }
@@ -607,7 +607,7 @@ fn test_string_push() {
 
 #[test]
 fn test_insert_at_length() {
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     let result1 = v.try_insert(0, "a");
     let result2 = v.try_insert(1, "b");
     assert!(result1.is_ok() && result2.is_ok());
@@ -617,7 +617,7 @@ fn test_insert_at_length() {
 #[should_panic]
 #[test]
 fn test_insert_out_of_bounds() {
-    let mut v = ArrayVec::<_,  8>::new();
+    let mut v = ArrayVec::<_, 8>::new();
     let _ = v.try_insert(1, "test");
 }
 
@@ -650,7 +650,7 @@ fn test_drop_in_insert() {
     flag.set(0);
 
     {
-        let mut array = ArrayVec::<_,  2>::new();
+        let mut array = ArrayVec::<_, 2>::new();
         array.push(Bump(flag));
         array.insert(0, Bump(flag));
         assert_eq!(flag.get(), 0);
@@ -665,7 +665,7 @@ fn test_drop_in_insert() {
 
 #[test]
 fn test_pop_at() {
-    let mut v = ArrayVec::<String,  4>::new();
+    let mut v = ArrayVec::<String, 4>::new();
     let s = String::from;
     v.push(s("a"));
     v.push(s("b"));
@@ -681,7 +681,7 @@ fn test_pop_at() {
 
 #[test]
 fn test_sizes() {
-    let v = ArrayVec::from([0u8; 1 << 16]);
+    let v: ArrayVec<_, { 1 << 16 }> = ArrayVec::from([0u8; 1 << 16]);
     assert_eq!(vec![0u8; v.len()], &v[..]);
 }
 
@@ -690,19 +690,19 @@ fn test_default() {
     use std::net;
     let s: ArrayString<4> = Default::default();
     // Something without `Default` implementation.
-    let v: ArrayVec<net::TcpStream,  4> = Default::default();
+    let v: ArrayVec<net::TcpStream, 4> = Default::default();
     assert_eq!(s.len(), 0);
     assert_eq!(v.len(), 0);
 }
 
-#[cfg(feature="array-sizes-33-128")]
+#[cfg(feature = "array-sizes-33-128")]
 #[test]
 fn test_sizes_33_128() {
     ArrayVec::from([0u8; 52]);
     ArrayVec::from([0u8; 127]);
 }
 
-#[cfg(feature="array-sizes-129-255")]
+#[cfg(feature = "array-sizes-129-255")]
 #[test]
 fn test_sizes_129_255() {
     ArrayVec::from([0u8; 237]);
@@ -715,14 +715,14 @@ fn test_extend_zst() {
     #[derive(Copy, Clone, PartialEq, Debug)]
     struct Z; // Zero sized type
 
-    let mut array: ArrayVec<_,  5> = range.by_ref().take(5).map(|_| Z).collect();
+    let mut array: ArrayVec<_, 5> = range.by_ref().take(5).map(|_| Z).collect();
     assert_eq!(&array[..], &[Z; 5]);
     assert_eq!(range.next(), Some(5));
 
     array.extend(range.by_ref().take(0).map(|_| Z));
     assert_eq!(range.next(), Some(6));
 
-    let mut array: ArrayVec<_,  10> = (0..3).map(|_| Z).collect();
+    let mut array: ArrayVec<_, 10> = (0..3).map(|_| Z).collect();
     assert_eq!(&array[..], &[Z; 3]);
     array.extend((3..5).map(|_| Z));
     assert_eq!(&array[..], &[Z; 5]);
@@ -739,27 +739,27 @@ fn test_try_from_argument() {
 #[test]
 fn allow_max_capacity_arrayvec_type() {
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}>;
+    let _v: ArrayVec<(), { usize::MAX }>;
 }
 
-#[should_panic(expected="largest supported capacity")]
+#[should_panic(expected = "largest supported capacity")]
 #[test]
 fn deny_max_capacity_arrayvec_value() {
     if mem::size_of::<usize>() <= mem::size_of::<u32>() {
         panic!("This test does not work on this platform. 'largest supported capacity'");
     }
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new();
+    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new();
 }
 
-#[should_panic(expected="index out of bounds")]
+#[should_panic(expected = "index out of bounds")]
 #[test]
 fn deny_max_capacity_arrayvec_value_const() {
     if mem::size_of::<usize>() <= mem::size_of::<u32>() {
         panic!("This test does not work on this platform. 'index out of bounds'");
     }
     // this type is allowed to be used (but can't be constructed)
-    let _v: ArrayVec<(), {usize::MAX}> = ArrayVec::new_const();
+    let _v: ArrayVec<(), { usize::MAX }> = ArrayVec::new_const();
 }
 
 #[test]


### PR DESCRIPTION
It's really a lot of work being done
This PR resolves #247, supersedes #248  
However, some things are broken:
type inference won't work for `ArrayVec::from([0; N])` like before
some functions like `len()` are no longer `const`, unless nightly is enabled

This PR is expected to be merged after #255