### PR TITLE
Implement ArrayVecRefMut to erase CAP

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -31,10 +31,11 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 /// The string is a contiguous value that you can store directly on the stack
 /// if needed.
 #[derive(Copy)]
+#[repr(C)]
 pub struct ArrayString<const CAP: usize> {
     // the `len` first elements of the array are initialized
-    xs: [MaybeUninit<u8>; CAP],
     len: LenUint,
+    xs: [MaybeUninit<u8>; CAP],
 }
 
 impl<const CAP: usize> Default for ArrayString<CAP>

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -715,7 +715,10 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
 
 impl<T, const CAP: usize> ArrayVecImpl for ArrayVec<T, CAP> {
     type Item = T;
-    const CAPACITY: usize = CAP;
+
+    fn capacity(&self) -> usize {
+        CAP
+    }
 
     fn len(&self) -> usize { self.len() }
 

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -23,6 +23,7 @@ use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use crate::LenUint;
 use crate::errors::CapacityError;
 use crate::arrayvec_impl::ArrayVecImpl;
+use crate::arrayvec_ref::ArrayVecRefMut;
 use crate::utils::MakeMaybeUninit;
 
 /// A vector with a fixed capacity.
@@ -704,6 +705,11 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// Return a raw mutable pointer to the vector's buffer.
     pub fn as_mut_ptr(&mut self) -> *mut T {
         ArrayVecImpl::as_mut_ptr(self)
+    }
+
+    /// Return an erased unique reference to self
+    pub fn as_ref_mut(&mut self) -> ArrayVecRefMut<T> {
+        ArrayVecRefMut::new(self)
     }
 }
 

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -39,10 +39,11 @@ use crate::utils::MakeMaybeUninit;
 ///
 /// It offers a simple API but also dereferences to a slice, so that the full slice API is
 /// available. The ArrayVec can be converted into a by value iterator.
+#[repr(C)]
 pub struct ArrayVec<T, const CAP: usize> {
+    len: LenUint,
     // the `len` first elements of the array are initialized
     xs: [MaybeUninit<T>; CAP],
-    len: LenUint,
 }
 
 impl<T, const CAP: usize> Drop for ArrayVec<T, CAP> {

--- a/src/arrayvec_impl.rs
+++ b/src/arrayvec_impl.rs
@@ -7,7 +7,7 @@ use crate::CapacityError;
 /// for length and element access.
 pub(crate) trait ArrayVecImpl {
     type Item;
-    const CAPACITY: usize;
+    fn capacity(&self) -> usize;
 
     fn len(&self) -> usize;
 
@@ -41,7 +41,7 @@ pub(crate) trait ArrayVecImpl {
     }
 
     fn try_push(&mut self, element: Self::Item) -> Result<(), CapacityError<Self::Item>> {
-        if self.len() < Self::CAPACITY {
+        if self.len() < self.capacity() {
             unsafe {
                 self.push_unchecked(element);
             }
@@ -53,7 +53,7 @@ pub(crate) trait ArrayVecImpl {
 
     unsafe fn push_unchecked(&mut self, element: Self::Item) {
         let len = self.len();
-        debug_assert!(len < Self::CAPACITY);
+        debug_assert!(len < self.capacity());
         ptr::write(self.as_mut_ptr().add(len), element);
         self.set_len(len + 1);
     }

--- a/src/arrayvec_ref.rs
+++ b/src/arrayvec_ref.rs
@@ -1,0 +1,33 @@
+use std::ops::{Deref, DerefMut};
+use crate::ArrayVec;
+
+// ArrayVecRef is useless because we have Deref<[T}> already
+
+/// A mutable reference to an ArrayVec
+/// It gives you all the access of a mutable reference to an ArrayVec
+/// instead only a few methods exposed by ArrayVecImpl
+pub struct ArrayVecRefMut<'a, T> {
+    vec: &'a mut ArrayVec<T, 0>,
+}
+
+impl<'a, T> ArrayVecRefMut<'a, T> {
+    pub fn new<const CAP: usize>(vec: &'a mut ArrayVec<T, CAP>) -> Self {
+        unsafe {
+            Self { vec: std::mem::transmute(vec) }
+        }
+    }
+}
+
+
+impl<'a, T> Deref for ArrayVecRefMut<'a, T> {
+    type Target = ArrayVec<T, 0>;
+    fn deref(&self) -> &Self::Target {
+        self.vec
+    }
+}
+
+impl<'a, T> DerefMut for ArrayVecRefMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vec
+    }
+}

--- a/src/arrayvec_ref.rs
+++ b/src/arrayvec_ref.rs
@@ -1,5 +1,5 @@
 use std::ops::{Deref, DerefMut};
-use crate::ArrayVec;
+use crate::{ArrayVec, CapacityError};
 
 // ArrayVecRef is useless because we have Deref<[T}> already
 
@@ -7,15 +7,37 @@ use crate::ArrayVec;
 /// It gives you all the access of a mutable reference to an ArrayVec
 /// instead only a few methods exposed by ArrayVecImpl
 pub struct ArrayVecRefMut<'a, T> {
+    cap: usize,
     vec: &'a mut ArrayVec<T, 0>,
 }
 
 impl<'a, T> ArrayVecRefMut<'a, T> {
     pub fn new<const CAP: usize>(vec: &'a mut ArrayVec<T, CAP>) -> Self {
         unsafe {
-            Self { vec: std::mem::transmute(vec) }
+            Self { cap: CAP, vec: std::mem::transmute(vec) }
         }
     }
+    pub const fn capacity(&self) -> usize { self.cap }
+    pub const fn is_full(&self) -> bool { self.vec.len() == self.capacity() }
+    pub const fn remaining_capacity(&self) -> usize {
+        self.capacity() - self.vec.len()
+    }
+    #[track_caller]
+    pub fn push(&mut self, element: T) {
+        self.try_push(element).unwrap()
+    }
+
+    pub fn try_push(&mut self, element: T) -> Result<(), CapacityError<T>> {
+        if self.len() < self.capacity() {
+            unsafe {
+                self.vec.push_unchecked(element);
+            }
+            Ok(())
+        } else {
+            Err(CapacityError::new(element))
+        }
+    }
+
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ macro_rules! assert_capacity_limit_const {
 }
 
 mod arrayvec_impl;
+mod arrayvec_ref;
 mod arrayvec;
 mod array_string;
 mod char;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,4 @@ pub use crate::array_string::ArrayString;
 pub use crate::errors::CapacityError;
 
 pub use crate::arrayvec::{ArrayVec, IntoIter, Drain};
+pub use crate::arrayvec_ref::ArrayVecRefMut;


### PR DESCRIPTION
A mutable reference to an ArrayVec
It gives you all the access of a mutable reference to an ArrayVec, instead of only a few methods exposed by ArrayVecImpl