### PR TITLE
Make `as_ptr` and `as_mut_ptr` on ArrayString public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Recent Changes (arrayvec)
 =========================
 
+## Unreleased
+- Add `as_ptr` and `as_mut_ptr` to `ArrayString` by @YuhanLiin
+
 ## 0.7.4
 
 - Add feature zeroize to support the `Zeroize` trait by @elichai

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -414,11 +414,13 @@ impl<const CAP: usize> ArrayString<CAP>
         self
     }
 
-    fn as_ptr(&self) -> *const u8 {
+    /// Return a raw pointer to the string's buffer.
+    pub fn as_ptr(&self) -> *const u8 {
         self.xs.as_ptr() as *const u8
     }
 
-    fn as_mut_ptr(&mut self) -> *mut u8 {
+    /// Return a raw mutable pointer to the string's buffer.
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.xs.as_mut_ptr() as *mut u8
     }
 }


### PR DESCRIPTION
Allows pointer operations on `ArrayString`. In particular, it allows access of the underlying array beyond the length of the string. These methods are already available on `ArrayVec`, so it makes to add them to the string as well.