### PR TITLE
Make `ArrayString::as_{mut_}ptr` public.

### DIFF
--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -414,11 +414,13 @@ impl<const CAP: usize> ArrayString<CAP>
         self
     }
 
-    fn as_ptr(&self) -> *const u8 {
+    /// Return a raw pointer to the string's buffer.
+    pub fn as_ptr(&self) -> *const u8 {
         self.xs.as_ptr() as *const u8
     }
 
-    fn as_mut_ptr(&mut self) -> *mut u8 {
+    /// Return a raw mutable pointer to the string's buffer.
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.xs.as_mut_ptr() as *mut u8
     }
 }


### PR DESCRIPTION
## Motivation

I currently get the pointer via `impl Deref<Target = str>` but Miri complains (stacked borrows) when I write past the end (in low-level serialization code).

`ArrayVec::as_{mut_}ptr` works for `ArrayVec`, so I just need the same thing for `ArrayString`.