### PR TITLE
Automatically document feature flag requirements on docs.rs by using the feature `doc_auto_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ debug = true
 debug = true
 
 [package.metadata.docs.rs]
-features = ["borsh", "serde", "zeroize"]
+all-features = true
 # Enables the `docsrs` config attribute when running on docs.rs,
 # which always uses the latest nightly compiler. 
 # Idea taken from <https://stackoverflow.com/a/70914430>.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ debug = true
 
 [package.metadata.docs.rs]
 features = ["borsh", "serde", "zeroize"]
+# Enables the `docsrs` cofig attribute when running on docs.rs,
+# which always uses the latest nightly compiler. 
+# Idea taken from <https://stackoverflow.com/a/70914430>.
 rustdoc-flags = ["--cfg", "docsrs"]
 
 [package.metadata.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ debug = true
 
 [package.metadata.docs.rs]
 features = ["borsh", "serde", "zeroize"]
-# Enables the `docsrs` cofig attribute when running on docs.rs,
+# Enables the `docsrs` config attribute when running on docs.rs,
 # which always uses the latest nightly compiler. 
 # Idea taken from <https://stackoverflow.com/a/70914430>.
 rustdoc-flags = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ debug = true
 
 [package.metadata.docs.rs]
 features = ["borsh", "serde", "zeroize"]
+rustdoc-flags = ["--cfg", "docsrs"]
 
 [package.metadata.release]
 no-dev-version = true

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -580,7 +580,6 @@ impl<const CAP: usize> FromStr for ArrayString<CAP>
 }
 
 #[cfg(feature="serde")]
-/// Requires crate feature `"serde"`
 impl<const CAP: usize> Serialize for ArrayString<CAP>
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -591,7 +590,6 @@ impl<const CAP: usize> Serialize for ArrayString<CAP>
 }
 
 #[cfg(feature="serde")]
-/// Requires crate feature `"serde"`
 impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP> 
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -629,7 +627,6 @@ impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP>
 }
 
 #[cfg(feature = "borsh")]
-/// Requires crate feature `"borsh"`
 impl<const CAP: usize> borsh::BorshSerialize for ArrayString<CAP> {
     fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         <str as borsh::BorshSerialize>::serialize(&*self, writer)
@@ -637,7 +634,6 @@ impl<const CAP: usize> borsh::BorshSerialize for ArrayString<CAP> {
 }
 
 #[cfg(feature = "borsh")]
-/// Requires crate feature `"borsh"`
 impl<const CAP: usize> borsh::BorshDeserialize for ArrayString<CAP> {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let len = <u32 as borsh::BorshDeserialize>::deserialize_reader(reader)? as usize;
@@ -683,7 +679,7 @@ impl<'a, const CAP: usize> TryFrom<fmt::Arguments<'a>> for ArrayString<CAP>
 }
 
 #[cfg(feature = "zeroize")]
-/// "Best efforts" zeroing of the `ArrayString`'s buffer when the `zeroize` feature is enabled.
+/// "Best efforts" zeroing of the `ArrayString`'s buffer.
 ///
 /// The length is set to 0, and the buffer is dropped and zeroized.
 /// Cannot ensure that previous moves of the `ArrayString` did not leave values on the stack.

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -850,7 +850,7 @@ impl<T, const CAP: usize> IntoIterator for ArrayVec<T, CAP> {
 
 
 #[cfg(feature = "zeroize")]
-/// "Best efforts" zeroing of the `ArrayVec`'s buffer when the `zeroize` feature is enabled.
+/// "Best efforts" zeroing of the `ArrayVec`'s buffer.
 ///
 /// The length is set to 0, and the buffer is dropped and zeroized.
 /// Cannot ensure that previous moves of the `ArrayVec` did not leave values on the stack.
@@ -1254,8 +1254,6 @@ impl<T, const CAP: usize> Ord for ArrayVec<T, CAP> where T: Ord {
 
 #[cfg(feature="std")]
 /// `Write` appends written data to the end of the vector.
-///
-/// Requires `features="std"`.
 impl<const CAP: usize> io::Write for ArrayVec<u8, CAP> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let len = cmp::min(self.remaining_capacity(), data.len());
@@ -1267,7 +1265,6 @@ impl<const CAP: usize> io::Write for ArrayVec<u8, CAP> {
 }
 
 #[cfg(feature="serde")]
-/// Requires crate feature `"serde"`
 impl<T: Serialize, const CAP: usize> Serialize for ArrayVec<T, CAP> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -1277,7 +1274,6 @@ impl<T: Serialize, const CAP: usize> Serialize for ArrayVec<T, CAP> {
 }
 
 #[cfg(feature="serde")]
-/// Requires crate feature `"serde"`
 impl<'de, T: Deserialize<'de>, const CAP: usize> Deserialize<'de> for ArrayVec<T, CAP> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>
@@ -1314,7 +1310,6 @@ impl<'de, T: Deserialize<'de>, const CAP: usize> Deserialize<'de> for ArrayVec<T
 }
 
 #[cfg(feature = "borsh")]
-/// Requires crate feature `"borsh"`
 impl<T, const CAP: usize> borsh::BorshSerialize for ArrayVec<T, CAP>
 where
     T: borsh::BorshSerialize,
@@ -1325,7 +1320,6 @@ where
 }
 
 #[cfg(feature = "borsh")]
-/// Requires crate feature `"borsh"`
 impl<T, const CAP: usize> borsh::BorshDeserialize for ArrayVec<T, CAP>
 where
     T: borsh::BorshDeserialize,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,7 +32,6 @@ impl<T> CapacityError<T> {
 const CAPERROR: &'static str = "insufficient capacity";
 
 #[cfg(feature="std")]
-/// Requires `features="std"`.
 impl<T: Any> Error for CapacityError<T> {}
 
 impl<T> fmt::Display for CapacityError<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.7/")]
 #![cfg_attr(not(feature="std"), no_std)]
+// This enables the nightly feature `doc_auto_cfg` when running on docs.rs,
+// which always uses the nightly compiler.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature="serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //!
 #![doc(html_root_url="https://docs.rs/arrayvec/0.7/")]
 #![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature="serde")]
 extern crate serde;


### PR DESCRIPTION
Thanks for the nice crate!

Since this is an unsolicited PR, I completely understand if it is not interesting.

This PR uses the idea discussed in [this](https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do/) stackoverflow post to automatically document all feature flag requirements on docs.rs. This way any future feature flag gated code does not have to worry about documenting what features it needs.

The feature requires a nightly compiler, but by conditionally enabling it only on docs.rs the MSRV of the crate is unchanged (docs.rs always uses the nightly compiler).

The result should look like this:
![bild](https://github.com/bluss/arrayvec/assets/44257381/3d1f2f2c-4320-4be8-854e-318db1006a7a)  
and this:  
![bild](https://github.com/bluss/arrayvec/assets/44257381/92a4069d-3f30-47b9-bf49-32ac53905276)
