### PR TITLE
Return a proper error for `into_inner`

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -21,7 +21,7 @@ use std::mem::MaybeUninit;
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 use crate::LenUint;
-use crate::errors::CapacityError;
+use crate::errors::{CapacityError, UnderfilledError};
 use crate::arrayvec_impl::ArrayVecImpl;
 use crate::utils::MakeMaybeUninit;
 
@@ -687,11 +687,15 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
 
     /// Return the inner fixed size array, if it is full to its capacity.
     ///
-    /// Return an `Ok` value with the array if length equals capacity,
-    /// return an `Err` with self otherwise.
-    pub fn into_inner(self) -> Result<[T; CAP], Self> {
+    /// # Errors
+    ///
+    /// This method will return an error if the array is not filled to its
+    /// capacity (see [`capacity`]).
+    /// 
+    /// [`capacity`]: #method.capacity
+    pub fn into_inner(self) -> Result<[T; CAP], UnderfilledError> {
         if self.len() < self.capacity() {
-            Err(self)
+            Err(UnderfilledError::new(self.capacity(), self.len()))
         } else {
             unsafe { Ok(self.into_inner_unchecked()) }
         }

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -693,9 +693,9 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// capacity (see [`capacity`]).
     /// 
     /// [`capacity`]: #method.capacity
-    pub fn into_inner(self) -> Result<[T; CAP], UnderfilledError> {
+    pub fn into_inner(self) -> Result<[T; CAP], UnderfilledError<T, CAP>> {
         if self.len() < self.capacity() {
-            Err(UnderfilledError::new(self.capacity(), self.len()))
+            Err(UnderfilledError::new(self))
         } else {
             unsafe { Ok(self.into_inner_unchecked()) }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,7 +50,7 @@ impl<T> fmt::Debug for CapacityError<T> {
 }
 
 /// Error value indicating that capacity is not completely filled
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct UnderfilledError<T, const CAP: usize>(ArrayVec<T, CAP>);
 
 impl<T, const CAP: usize> UnderfilledError<T, CAP> {
@@ -63,11 +63,27 @@ impl<T, const CAP: usize> UnderfilledError<T, CAP> {
     }
 }
 
-#[cfg(feature="std")]
-impl<T: fmt::Debug, const CAP: usize> Error for UnderfilledError<T, CAP> {}
+impl<T, const CAP: usize> fmt::Debug for UnderfilledError<T, CAP> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "UnderfilledError: capacity is not filled: expected {}, got {}",
+            CAP,
+            self.0.len()
+        )
+    }
+}
 
-impl<T, const CAP: usize> fmt::Display for UnderfilledError<T, CAP> { 
+#[cfg(feature="std")]
+impl<T, const CAP: usize> Error for UnderfilledError<T, CAP> {}
+
+impl<T, const CAP: usize> fmt::Display for UnderfilledError<T, CAP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "capacity is not filled: expected {}, got {}", CAP, self.0.len())
+        write!(
+            f,
+            "capacity is not filled: expected {}, got {}",
+            CAP,
+            self.0.len()
+        )
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,3 +47,24 @@ impl<T> fmt::Debug for CapacityError<T> {
     }
 }
 
+/// Error value indicating that capacity is not completely filled
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct UnderfilledError {
+    capacity: usize,
+    len: usize,
+}
+
+impl UnderfilledError {
+    pub const fn new(capacity: usize, len: usize) -> Self {
+        Self { capacity, len }
+    }
+}
+
+#[cfg(feature="std")]
+impl Error for UnderfilledError {}
+
+impl fmt::Display for UnderfilledError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "capacity is not filled: expected {}, got {}", self.capacity, self.len)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,8 @@ use std::any::Any;
 #[cfg(feature="std")]
 use std::error::Error;
 
+use crate::ArrayVec;
+
 /// Error value indicating insufficient capacity
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct CapacityError<T = ()> {
@@ -48,23 +50,24 @@ impl<T> fmt::Debug for CapacityError<T> {
 }
 
 /// Error value indicating that capacity is not completely filled
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct UnderfilledError {
-    capacity: usize,
-    len: usize,
-}
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct UnderfilledError<T, const CAP: usize>(ArrayVec<T, CAP>);
 
-impl UnderfilledError {
-    pub const fn new(capacity: usize, len: usize) -> Self {
-        Self { capacity, len }
+impl<T, const CAP: usize> UnderfilledError<T, CAP> {
+    pub const fn new(inner: ArrayVec<T, CAP>) -> Self {
+        Self(inner)
+    }
+
+    pub fn take_vec(self) -> ArrayVec<T, CAP> {
+        self.0
     }
 }
 
 #[cfg(feature="std")]
-impl Error for UnderfilledError {}
+impl<T: fmt::Debug, const CAP: usize> Error for UnderfilledError<T, CAP> {}
 
-impl fmt::Display for UnderfilledError {
+impl<T, const CAP: usize> fmt::Display for UnderfilledError<T, CAP> { 
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "capacity is not filled: expected {}, got {}", self.capacity, self.len)
+        write!(f, "capacity is not filled: expected {}, got {}", CAP, self.0.len())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,6 @@ mod errors;
 mod utils;
 
 pub use crate::array_string::ArrayString;
-pub use crate::errors::CapacityError;
+pub use crate::errors::{CapacityError, UnderfilledError};
 
 pub use crate::arrayvec::{ArrayVec, IntoIter, Drain};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -456,7 +456,8 @@ fn test_insert() {
 fn test_into_inner_1() {
     let mut v = ArrayVec::from([1, 2]);
     v.pop();
-    assert_eq!(v.into_inner(), Err(UnderfilledError::new(2, 1)));
+    let u = v.clone();
+    assert_eq!(v.into_inner(), Err(UnderfilledError::new(u)));
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,6 +3,7 @@ extern crate arrayvec;
 
 use arrayvec::ArrayVec;
 use arrayvec::ArrayString;
+use arrayvec::UnderfilledError;
 use std::mem;
 use arrayvec::CapacityError;
 
@@ -455,8 +456,7 @@ fn test_insert() {
 fn test_into_inner_1() {
     let mut v = ArrayVec::from([1, 2]);
     v.pop();
-    let u = v.clone();
-    assert_eq!(v.into_inner(), Err(u));
+    assert_eq!(v.into_inner(), Err(UnderfilledError::new(2, 1)));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a new error type representing an under-filled state for `ArrayVec::into_inner`. Previously, it would return `self` which is rather unconventional and prevents ergonomic error propagation (e.g. with `?`).