### PR TITLE
Fix warning about hidden elided lifetime in `Drain`

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -637,7 +637,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(&v1[..], &[3]);
     /// assert_eq!(&v2[..], &[1, 2]);
     /// ```
-    pub fn drain<R>(&mut self, range: R) -> Drain<T, CAP>
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T, CAP>
         where R: RangeBounds<usize>
     {
         // Memory safety
@@ -664,7 +664,7 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
         self.drain_range(start, end)
     }
 
-    fn drain_range(&mut self, start: usize, end: usize) -> Drain<T, CAP>
+    fn drain_range(&mut self, start: usize, end: usize) -> Drain<'_, T, CAP>
     {
         let len = self.len();
 


### PR DESCRIPTION
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/arrayvec.rs:640:21
    |
640 |     pub fn drain<R>(&mut self, range: R) -> Drain<T, CAP>
    |                     ^^^^^^^^^               ^^^^^^^^^^^^^ the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
640 |     pub fn drain<R>(&mut self, range: R) -> Drain<'_, T, CAP>
    |                                                   +++
```