### PR TITLE
Add optional Diesel support and cleanup a bunch of newer Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ version = "1.2.0"
 optional = true
 default-features = false
 
+[dependencies.diesel]
+version = "2.3.4"
+optional = true
+default-features = false
+
 [dependencies.serde]
 version = "1.0"
 optional = true

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -311,10 +311,7 @@ impl<const CAP: usize> ArrayString<CAP>
     /// assert_eq!(s.pop(), None);
     /// ```
     pub fn pop(&mut self) -> Option<char> {
-        let ch = match self.chars().rev().next() {
-            Some(ch) => ch,
-            None => return None,
-        };
+        let ch = self.chars().next_back()?;
         let new_len = self.len() - ch.len_utf8();
         unsafe {
             self.set_len(new_len);
@@ -396,6 +393,7 @@ impl<const CAP: usize> ArrayString<CAP>
 
     /// Set the strings’s length.
     ///
+    /// # Safety
     /// This function is `unsafe` because it changes the notion of the
     /// number of “valid” bytes in the string. Use with care.
     ///
@@ -408,21 +406,25 @@ impl<const CAP: usize> ArrayString<CAP>
     }
 
     /// Return a string slice of the whole `ArrayString`.
+    #[inline]
     pub fn as_str(&self) -> &str {
         self
     }
 
     /// Return a mutable string slice of the whole `ArrayString`.
+    #[inline]
     pub fn as_mut_str(&mut self) -> &mut str {
         self
     }
 
     /// Return a raw pointer to the string's buffer.
+    #[inline]
     pub fn as_ptr(&self) -> *const u8 {
         self.xs.as_ptr() as *const u8
     }
 
     /// Return a raw mutable pointer to the string's buffer.
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.xs.as_mut_ptr() as *mut u8
     }
@@ -470,6 +472,20 @@ impl<const CAP: usize> PartialEq<ArrayString<CAP>> for str
 {
     fn eq(&self, rhs: &ArrayString<CAP>) -> bool {
         self == &**rhs
+    }
+}
+
+impl<const CAP: usize> PartialEq<&str> for ArrayString<CAP>
+{
+    fn eq(&self, rhs: &&str) -> bool {
+        self == *rhs
+    }
+}
+
+impl<const CAP: usize> PartialEq<ArrayString<CAP>> for &str
+{
+    fn eq(&self, rhs: &ArrayString<CAP>) -> bool {
+        *self == rhs
     }
 }
 
@@ -527,6 +543,7 @@ impl<const CAP: usize> fmt::Write for ArrayString<CAP>
     }
 }
 
+#[expect(clippy::non_canonical_clone_impl)]
 impl<const CAP: usize> Clone for ArrayString<CAP>
 {
     fn clone(&self) -> ArrayString<CAP> {
@@ -542,40 +559,42 @@ impl<const CAP: usize> Clone for ArrayString<CAP>
 impl<const CAP: usize> PartialOrd for ArrayString<CAP>
 {
     fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
-        (**self).partial_cmp(&**rhs)
+        Some(self.cmp(rhs))
     }
-    fn lt(&self, rhs: &Self) -> bool { **self < **rhs }
-    fn le(&self, rhs: &Self) -> bool { **self <= **rhs }
-    fn gt(&self, rhs: &Self) -> bool { **self > **rhs }
-    fn ge(&self, rhs: &Self) -> bool { **self >= **rhs }
 }
 
 impl<const CAP: usize> PartialOrd<str> for ArrayString<CAP>
 {
     fn partial_cmp(&self, rhs: &str) -> Option<cmp::Ordering> {
-        (**self).partial_cmp(rhs)
+        self.as_str().partial_cmp(rhs)
     }
-    fn lt(&self, rhs: &str) -> bool { &**self < rhs }
-    fn le(&self, rhs: &str) -> bool { &**self <= rhs }
-    fn gt(&self, rhs: &str) -> bool { &**self > rhs }
-    fn ge(&self, rhs: &str) -> bool { &**self >= rhs }
 }
 
 impl<const CAP: usize> PartialOrd<ArrayString<CAP>> for str
 {
     fn partial_cmp(&self, rhs: &ArrayString<CAP>) -> Option<cmp::Ordering> {
-        self.partial_cmp(&**rhs)
+        self.partial_cmp(rhs.as_str())
     }
-    fn lt(&self, rhs: &ArrayString<CAP>) -> bool { self < &**rhs }
-    fn le(&self, rhs: &ArrayString<CAP>) -> bool { self <= &**rhs }
-    fn gt(&self, rhs: &ArrayString<CAP>) -> bool { self > &**rhs }
-    fn ge(&self, rhs: &ArrayString<CAP>) -> bool { self >= &**rhs }
+}
+
+impl<const CAP: usize> PartialOrd<&str> for ArrayString<CAP>
+{
+    fn partial_cmp(&self, rhs: &&str) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(*rhs)
+    }
+}
+
+impl<const CAP: usize> PartialOrd<ArrayString<CAP>> for &str
+{
+    fn partial_cmp(&self, rhs: &ArrayString<CAP>) -> Option<cmp::Ordering> {
+        (*self).partial_cmp(rhs.as_str())
+    }
 }
 
 impl<const CAP: usize> Ord for ArrayString<CAP>
 {
     fn cmp(&self, rhs: &Self) -> cmp::Ordering {
-        (**self).cmp(&**rhs)
+        self.as_str().cmp(rhs.as_str())
     }
 }
 
@@ -595,7 +614,7 @@ impl<const CAP: usize> Serialize for ArrayString<CAP>
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        serializer.serialize_str(&*self)
+        serializer.serialize_str(self)
     }
 }
 
@@ -641,7 +660,7 @@ impl<'de, const CAP: usize> Deserialize<'de> for ArrayString<CAP>
 /// Requires crate feature `"borsh"`
 impl<const CAP: usize> borsh::BorshSerialize for ArrayString<CAP> {
     fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
-        <str as borsh::BorshSerialize>::serialize(&*self, writer)
+        <str as borsh::BorshSerialize>::serialize(self, writer)
     }
 }
 
@@ -661,7 +680,7 @@ impl<const CAP: usize> borsh::BorshDeserialize for ArrayString<CAP> {
         let buf = &mut buf[..len];
         reader.read_exact(buf)?;
 
-        let s = str::from_utf8(&buf).map_err(|err| {
+        let s = str::from_utf8(buf).map_err(|err| {
             borsh::io::Error::new(borsh::io::ErrorKind::InvalidData, err.to_string())
         })?;
         Ok(Self::from(s).unwrap())
@@ -686,7 +705,7 @@ impl<'a, const CAP: usize> TryFrom<fmt::Arguments<'a>> for ArrayString<CAP>
     fn try_from(f: fmt::Arguments<'a>) -> Result<Self, Self::Error> {
         use fmt::Write;
         let mut v = Self::new();
-        v.write_fmt(f).map_err(|e| CapacityError::new(e))?;
+        v.write_fmt(f).map_err(CapacityError::new)?;
         Ok(v)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ impl<T> CapacityError<T> {
     /// Create a new `CapacityError` from `element`.
     pub const fn new(element: T) -> CapacityError<T> {
         CapacityError {
-            element: element,
+            element,
         }
     }
 
@@ -29,7 +29,7 @@ impl<T> CapacityError<T> {
     }
 }
 
-const CAPERROR: &'static str = "insufficient capacity";
+const CAPERROR: &str = "insufficient capacity";
 
 #[cfg(feature="std")]
 /// Requires `features="std"`.
@@ -43,7 +43,7 @@ impl<T> fmt::Display for CapacityError<T> {
 
 impl<T> fmt::Debug for CapacityError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", "CapacityError", CAPERROR)
+        write!(f, "CapacityError: {}", CAPERROR)
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -557,7 +557,7 @@ fn test_string() {
 #[test]
 fn test_string_from() {
     let text = "hello world";
-	// Test `from` constructor
+    // Test `from` constructor
     let u = ArrayString::<11>::from(text).unwrap();
     assert_eq!(&u, text);
     assert_eq!(u.len(), text.len());
@@ -774,3 +774,20 @@ fn test_arraystring_zero_filled_has_some_sanity_checks() {
     assert_eq!(string.as_str(), "\0\0\0\0");
     assert_eq!(string.len(), 4);
 }
+
+#[test]
+fn test_arraystring_ord() {
+    let a_arraystring: ArrayString<1> = ArrayString::from("a").unwrap();
+    let b_arraystring: ArrayString<1> = ArrayString::from("b").unwrap();
+
+    let a_str = "a";
+    let b_str = "b";
+
+    assert!(a_arraystring < b_arraystring);
+    assert!(b_arraystring > a_arraystring);
+    assert!(a_arraystring < b_str);
+    assert!(a_str < b_arraystring);
+    assert!(b_arraystring > a_str);
+    assert!(b_str > a_arraystring);
+}
+


### PR DESCRIPTION
Also add `#[inline]` markers to some very small public functions and convenience `PartialEq<&str>` impls for `ArrayString`.  Part of the Clippy lint cleanup involved significant changes to the `PartialOrd` impls, but codegen doesn't seem to be impacted.