### PR TITLE
Fix double-free for ZSTs with Drop in .extend()

### DIFF
--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1137,6 +1137,11 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
                 debug_assert_ne!(ptr, end_ptr);
                 if mem::size_of::<T>() != 0 {
                     ptr.write(elt);
+                } else {
+                    // The ZST element has logically been moved into the vector.
+                    // There is no memory to write, but dropping `elt` here would
+                    // drop it once now and once again when the vector is dropped.
+                    mem::forget(elt);
                 }
                 ptr = raw_ptr_add(ptr, 1);
                 guard.data += 1;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -717,6 +717,32 @@ fn test_extend_zst() {
 }
 
 #[test]
+fn test_extend_zst_with_drop_is_not_dropped_twice_via_safe_api() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct ZstWithSafeDrop;
+
+    impl Drop for ZstWithSafeDrop {
+        fn drop(&mut self) {
+            let previous = DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+            // Extending with a single ZST moves one logical value into the ArrayVec.
+            // Its Drop implementation must run exactly once, when the ArrayVec drops.
+            if previous != 0 {
+                panic!("ZST value dropped more than once");
+            }
+        }
+    }
+
+    DROP_COUNT.store(0, Ordering::SeqCst);
+
+    let mut vec = ArrayVec::<ZstWithSafeDrop, 1>::new();
+    vec.extend(std::iter::once(ZstWithSafeDrop));
+    drop(vec);
+}
+
+#[test]
 fn test_try_from_argument() {
     use core::convert::TryFrom;
     let v = ArrayString::<16>::try_from(format_args!("Hello {}", 123)).unwrap();


### PR DESCRIPTION
Zero-sized types that `impl Drop` get dropped twice in `.extend()`. This PR adds a test to demonstrate it, and fixes the issue.

This is a soundness bug, but likely not a big deal in practice, since this kind of type is really uncommon.

The issue was discovered by GPT-5.5 high