### PR TITLE
Add `if len > CAP { unreachable_unchecked() }`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ harness = false
 name = "clone"
 harness = false
 
+[[bench]]
+name = "sum"
+harness = false
+
 [features]
 default = ["std"]
 std = []

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -1,0 +1,44 @@
+
+extern crate arrayvec;
+#[macro_use] extern crate bencher;
+
+use arrayvec::ArrayVec;
+
+use bencher::Bencher;
+use bencher::black_box;
+
+fn sum_x<const N: usize>(b: &mut Bencher) {
+    let mut v = ArrayVec::<u8, N>::new();
+    v.extend((0..N).map(|x| x as u8));
+    b.iter(|| {
+        let mut overall_sum: u8 = 0;
+        for _ in 0..100 {
+            let v = black_box(&v);
+            let mut sum: u8 = 0;
+            for i in 0..v.len() {
+                sum = sum.wrapping_add(v[i]);
+            }
+            overall_sum = overall_sum.wrapping_add(black_box(sum));
+        }
+        black_box(overall_sum)
+    });
+    b.bytes = v.len() as u64;
+}
+
+fn sum_1(b: &mut Bencher) {
+    sum_x::<1>(b);
+}
+fn sum_16(b: &mut Bencher) {
+    sum_x::<16>(b);
+}
+fn sum_128(b: &mut Bencher) {
+    sum_x::<128>(b);
+}
+
+benchmark_group!(benches,
+                 sum_1,
+                 sum_16,
+                 sum_128,
+);
+
+benchmark_main!(benches);

--- a/src/array_string.rs
+++ b/src/array_string.rs
@@ -85,7 +85,14 @@ impl<const CAP: usize> ArrayString<CAP>
 
     /// Return the length of the string.
     #[inline]
-    pub const fn len(&self) -> usize { self.len as usize }
+    pub const fn len(&self) -> usize {
+        let len = self.len as usize;
+        if len <= CAP {
+            len
+        } else {
+            unsafe { std::hint::unreachable_unchecked() }
+        }
+    }
 
     /// Returns whether the string is empty.
     #[inline]

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -111,7 +111,14 @@ impl<T, const CAP: usize> ArrayVec<T, CAP> {
     /// assert_eq!(array.len(), 2);
     /// ```
     #[inline(always)]
-    pub const fn len(&self) -> usize { self.len as usize }
+    pub const fn len(&self) -> usize {
+        let len = self.len as usize;
+        if len <= CAP {
+            len
+        } else {
+            unsafe { std::hint::unreachable_unchecked() }
+        }
+    }
 
     /// Returns whether the `ArrayVec` is empty.
     ///


### PR DESCRIPTION
First of all, love the library! use it all the time 😄 

This PR add a `if len > CAP { unreachable_unchecked() }` call in `ArrayVec::len()`.
We know this assumption, and telling the compiler about it let it generate better code and eliminate some bound checks.

It also include a small benchmark for `ArrayVec::clone()` that demonstrate the (massive) speed up.
```bash
# before
> cargo bench clone
running 2 tests
test clone_512 ... bench:         345 ns/iter (+/- 20) = 1484 MB/s
test clone_8   ... bench:           4 ns/iter (+/- 0) = 2000 MB/s

# after
> cargo bench clone
running 2 tests
test clone_512 ... bench:         205 ns/iter (+/- 15) = 2497 MB/s
test clone_8   ... bench:           2 ns/iter (+/- 0) = 4000 MB/s
```
Clone is my specific use case, but im sure other generated code is more optimized when the compiler knows this.

Thanks for the support in advance ❤️ 