### PR TITLE
Optimize ArrayVec::clone() to behave like Copy when T: Copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ harness = false
 name = "arraystring"
 harness = false
 
+[[bench]]
+name = "clone"
+harness = false
+
 [features]
 default = ["std"]
 std = []

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -1,0 +1,43 @@
+
+extern crate arrayvec;
+#[macro_use] extern crate bencher;
+
+use arrayvec::ArrayVec;
+
+use bencher::Bencher;
+use bencher::black_box;
+
+fn clone_x<const N: usize>(b: &mut Bencher) {
+    let mut v = ArrayVec::<u8, N>::new();
+    v.extend((0..N).map(|x| x as u8));
+    b.iter(|| {
+        black_box(v.clone())
+    });
+    b.bytes = v.len() as u64;
+}
+
+fn clone_8(b: &mut Bencher) {
+    clone_x::<8>(b);
+}
+fn clone_16(b: &mut Bencher) {
+    clone_x::<16>(b);
+}
+fn clone_32(b: &mut Bencher) {
+    clone_x::<32>(b);
+}
+fn clone_64(b: &mut Bencher) {
+    clone_x::<64>(b);
+}
+fn clone_512(b: &mut Bencher) {
+    clone_x::<512>(b);
+}
+
+benchmark_group!(benches,
+                 clone_8,
+                 clone_16,
+                 clone_32,
+                 clone_64,
+                 clone_512
+);
+
+benchmark_main!(benches);

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1193,7 +1193,62 @@ impl<T, const CAP: usize> Clone for ArrayVec<T, CAP>
     where T: Clone
 {
     fn clone(&self) -> Self {
-        self.iter().cloned().collect()
+        let mut array: ArrayVec<T, CAP> = ArrayVec::new();
+        {
+            let mut guard = ScopeExitGuard {
+                value: &mut array.len,
+                data: 0 as LenUint,
+                f: move |&len, self_len| {
+                    **self_len = len;
+                },
+            };
+
+            for i in 0..CAP {
+                if i < self.len() {
+                    let val = unsafe { &*self.xs[i].as_ptr() }.clone();
+                    if mem::size_of::<T>() != 0 {
+                        unsafe { array.xs[i].as_mut_ptr().write(val) };
+                    } else {
+                        // The ZST element has logically been moved into the vector.
+                        // There is no memory to write, but dropping `elt` here would
+                        // drop it once now and once again when the vector is dropped.
+                        mem::forget(val);
+                    }
+                    guard.data += 1;
+                } else {
+                    // we are done copying all the elements.
+                    // we continue to copy uninitialized elements past len up to CAP. This seems
+                    // weird and counter intuitive, but when T is trivial (like i8/i32), copying the
+                    // whole array is faster as the compiler doesnt have to loop up to len, and the
+                    // generated code is branchless copy of the whole struct (like Copy).
+                    //
+                    // We only do it if;
+                    // - T does not requires drop, which we take as an indication that T::clone()
+                    //   is not trivial and therefore the loop will not be optimized away by the
+                    //   compiler.
+                    // - size_of > 0, to avoid reading self.xs[i].as_ptr()
+                    // - the total array is less or equal to 128 bytes. An arbitrary threshold to
+                    //   avoid unnecessary copying of large arrays.
+                    if mem::needs_drop::<T>()
+                        || mem::size_of::<T>() == 0
+                        || CAP > 128 / mem::size_of::<T>()
+                    {
+                        break;
+                    }
+                    // Safety: copy of MaybeUninit to MaybeUninit
+                    unsafe { ptr::copy_nonoverlapping(&self.xs[i], &mut array.xs[i], 1) };
+                }
+            }
+        }
+
+        // This assignment seems redundant as guard.data is already equal to len and will set the
+        // array len on drop, but setting it here explicitly helps the compiler understand it
+        // can just copy the len instead of accumulating it in the guard. This is especially
+        // useful for T::clone() that can not panic.
+        debug_assert_eq!(array.len, self.len);
+        array.len = self.len;
+
+        array
     }
 
     fn clone_from(&mut self, rhs: &Self) {

--- a/src/arrayvec.rs
+++ b/src/arrayvec.rs
@@ -1193,61 +1193,46 @@ impl<T, const CAP: usize> Clone for ArrayVec<T, CAP>
     where T: Clone
 {
     fn clone(&self) -> Self {
-        let mut array: ArrayVec<T, CAP> = ArrayVec::new();
-        {
-            let mut guard = ScopeExitGuard {
-                value: &mut array.len,
-                data: 0 as LenUint,
-                f: move |&len, self_len| {
-                    **self_len = len;
-                },
-            };
+        let mut array = Self::new();
 
-            for i in 0..CAP {
-                if i < self.len() {
-                    let val = unsafe { &*self.xs[i].as_ptr() }.clone();
-                    if mem::size_of::<T>() != 0 {
-                        unsafe { array.xs[i].as_mut_ptr().write(val) };
-                    } else {
-                        // The ZST element has logically been moved into the vector.
-                        // There is no memory to write, but dropping `elt` here would
-                        // drop it once now and once again when the vector is dropped.
-                        mem::forget(val);
-                    }
-                    guard.data += 1;
-                } else {
-                    // we are done copying all the elements.
-                    // we continue to copy uninitialized elements past len up to CAP. This seems
-                    // weird and counter intuitive, but when T is trivial (like i8/i32), copying the
-                    // whole array is faster as the compiler doesnt have to loop up to len, and the
-                    // generated code is branchless copy of the whole struct (like Copy).
-                    //
-                    // We only do it if;
-                    // - T does not requires drop, which we take as an indication that T::clone()
-                    //   is not trivial and therefore the loop will not be optimized away by the
-                    //   compiler.
-                    // - size_of > 0, to avoid reading self.xs[i].as_ptr()
-                    // - the total array is less or equal to 128 bytes. An arbitrary threshold to
-                    //   avoid unnecessary copying of large arrays.
-                    if mem::needs_drop::<T>()
-                        || mem::size_of::<T>() == 0
-                        || CAP > 128 / mem::size_of::<T>()
-                    {
-                        break;
-                    }
-                    // Safety: copy of MaybeUninit to MaybeUninit
-                    unsafe { ptr::copy_nonoverlapping(&self.xs[i], &mut array.xs[i], 1) };
+        for i in 0..CAP {
+            if i < self.len() {
+                // Safety: known to not exceed capacity
+                unsafe {
+                    array.push_unchecked(self[i].clone());
                 }
-            }
+            } else {
+                // we are done copying all the elements.
+                // we continue to copy uninitialized elements past len up to CAP. This seems
+                // weird and counter intuitive, but when T is trivial (like i8/i32), copying the
+                // whole array is faster as the compiler doesnt have to loop up to len, and the
+                // generated code is branchless copy of the whole struct (like Copy).
+                //
+                // We only do it if:
+                // - T does not require drop, which we take as an indication that T::clone()
+                //   is not trivial and therefore the loop will not be optimized away by the
+                //   compiler.
+                // - size_of > 0, to avoid reading self.xs[i].as_ptr()
+                // - the total array is less or equal to 128 bytes. An arbitrary threshold to
+                //   avoid unnecessary copying of large arrays.
+                if mem::needs_drop::<T>()
+                    || mem::size_of::<T>() == 0
+                    || CAP > 128 / mem::size_of::<T>()
+                {
+                    break;
+                }
+
+                // Safety: copy as MaybeUninit<T>
+                unsafe {
+                    ptr::copy_nonoverlapping(&self.xs[i], &mut array.xs[i], 1);
+                }
+            };
         }
 
-        // This assignment seems redundant as guard.data is already equal to len and will set the
-        // array len on drop, but setting it here explicitly helps the compiler understand it
-        // can just copy the len instead of accumulating it in the guard. This is especially
-        // useful for T::clone() that can not panic.
-        debug_assert_eq!(array.len, self.len);
+        // This assignment helps the compiler understand it can just copy the len instead
+        // of using the accumulated value.
+        // This is especially useful for T::clone() that can not panic.
         array.len = self.len;
-
         array
     }
 

--- a/tests/codegen/clone_copy.rs
+++ b/tests/codegen/clone_copy.rs
@@ -1,0 +1,8 @@
+extern crate arrayvec;
+use arrayvec::ArrayVec;
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+pub fn test_subject(array: &ArrayVec<u8, 8>) -> ArrayVec<u8, 8> {
+    array.clone()
+}

--- a/tests/codegen/justfile
+++ b/tests/codegen/justfile
@@ -1,0 +1,51 @@
+root := "../.."
+
+default: check
+
+build-deps:
+    cd {{root}} && cargo build --release
+
+# Compile and inspect the asm for .clone() testcase
+# Require that it's very short (should be like a short struct copy)
+check: build-deps
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    ROOT={{root}}
+    asm=$(rustc --edition 2024 -C opt-level=3 --crate-type lib \
+        clone_copy.rs -L "$ROOT/target/release/deps" \
+        --emit=asm -o -)
+
+    fail=
+
+    FUNC=test_subject
+    MAXBODY=20
+
+    # Sanity check
+    echo "$asm" | grep -q "$FUNC.*:" || { echo "FAIL: $FUNC label missing"; fail=1; }
+
+    # Assertions
+    echo "$asm" | grep -q -E 'memcpy|memmove' && { echo "FAIL: references memcpy"; fail=1; }
+    echo "$asm" | grep -q -E 'panic' && { echo "FAIL: references panic"; fail=1; }
+
+    # Extract the function body
+    body=$(echo "$asm" | sed -n "/$FUNC.*:$/,/\.cfi_endproc/p")
+    nlines=$(echo "$body" | wc -l | tr -d ' ')
+    if [ "$nlines" -gt "$MAXBODY" ]; then
+        echo "FAIL: body too long"
+        fail=1
+    fi
+
+
+    if [ "${fail:-0}" = 1 ]; then
+        echo "--- output (full) ---"
+        echo "$asm"
+        echo "--- end ---"
+        exit 1
+    else
+        echo "--- output (body) ---"
+        echo "$body"
+        echo "--- end ---"
+    fi
+
+    echo "PASS: function $FUNC"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -28,6 +28,27 @@ fn test_simple() {
 }
 
 #[test]
+fn test_clone_simple() {
+    let data = [1, 2, 3, 4, 5, 6, 7];
+    let mut vec = ArrayVec::from(data);
+    vec.pop();
+
+    let u = vec.clone();
+    assert_eq!(vec, u);
+    assert_eq!(&vec, &data[..data.len() - 1]);
+}
+
+#[test]
+fn test_clone_complex() {
+    let mut vec: ArrayVec<Vec<i32>,  3> = ArrayVec::new();
+
+    vec.push(vec![1, 2, 3, 4]);
+    vec.push(vec![10]);
+    let u = vec.clone();
+    assert_eq!(vec, u);
+}
+
+#[test]
 fn test_capacity_left() {
     let mut vec: ArrayVec<usize,  4> = ArrayVec::new();
     assert_eq!(vec.remaining_capacity(), 4);


### PR DESCRIPTION
First of all, love the library! use it all the time 😄 

This PR optimize `ArrayVec::clone()` by copying elements past `len` up to `CAP`. This sounds weird and counter intuitive, but for small arrays of trivial types this optimizations remove bound checks and compiles to very simple assembly.

It also include a small benchmark for `ArrayVec::clone()` that demonstrate the speed up.
```bash
# before
> cargo bench clone
running 5 tests
test clone_16  ... bench:           7 ns/iter (+/- 0) = 2285 MB/s
test clone_32  ... bench:          22 ns/iter (+/- 2) = 1454 MB/s
test clone_512 ... bench:         327 ns/iter (+/- 14) = 1565 MB/s
test clone_64  ... bench:          33 ns/iter (+/- 4) = 1939 MB/s
test clone_8   ... bench:           4 ns/iter (+/- 0) = 2000 MB/s

# after
> cargo bench clone
running 5 tests
test clone_16  ... bench:           3 ns/iter (+/- 0) = 5333 MB/s
test clone_32  ... bench:           8 ns/iter (+/- 0) = 4000 MB/s
test clone_512 ... bench:         199 ns/iter (+/- 15) = 2572 MB/s
test clone_64  ... bench:          24 ns/iter (+/- 3) = 2666 MB/s
test clone_8   ... bench:           1 ns/iter (+/- 1) = 8000 MB/s
```
As you can see in the code, i bounded the optimization to 128 bytes, but apparently even 512 CAP arrays get a speed up. I didnt check, but my guess is that the asm is simpler without the iterator.

For a simple function like this one:
```rust
#[inline(never)]
fn do_work(array: &ArrayVec<u8, 8>) -> ArrayVec<u8, 8> {
    array.clone()
}
```
This is the assembly on my machine after the PR:
```asm
hello::do_work:
Lfunc_begin6:
        .cfi_startproc
        ldr w8, [x1]
        str w8, [x0]
        ldur d0, [x1, #4]
        stur d0, [x0, #4]
        ret
```
This is the same function before the PR:
```asm
hello::do_work:
Lfunc_begin6:
        .cfi_startproc
        sub sp, sp, #96
        .cfi_def_cfa_offset 96
        stp x26, x25, [sp, #16]
        stp x24, x23, [sp, #32]
        stp x22, x21, [sp, #48]
        stp x20, x19, [sp, #64]
        stp x29, x30, [sp, #80]
        add x29, sp, #80
        .cfi_def_cfa w29, 16
        .cfi_offset w30, -8
        .cfi_offset w29, -16
        .cfi_offset w19, -24
        .cfi_offset w20, -32
        .cfi_offset w21, -40
        .cfi_offset w22, -48
        .cfi_offset w23, -56
        .cfi_offset w24, -64
        .cfi_offset w25, -72
        .cfi_offset w26, -80
        mov x19, x0
        ldr w21, [x1]
        cbz w21, LBB6_6
        mov x23, #0
        add x8, x1, x21
        add x22, x8, #4
        add x24, x1, #4
        add x8, sp, #4
        add x25, x8, #4
Lloh6:
        adrp x20, l___unnamed_3@PAGE
Lloh7:
        add x20, x20, l___unnamed_3@PAGEOFF
        b LBB6_3
LBB6_2:
        strb w26, [x25, x23]
        add x23, x23, #1
        cmp x21, x23
        b.eq LBB6_5
LBB6_3:
        ldrb w26, [x24, x23]
        cmp x23, #8
        b.ne LBB6_2
        mov x0, x20
        bl arrayvec::arrayvec::extend_panic
        b LBB6_2
LBB6_5:
        sub w8, w22, w24
        b LBB6_7
LBB6_6:
        mov w8, #0
LBB6_7:
        str w8, [sp, #4]
        ldr w8, [sp, #12]
        str w8, [x19, #8]
        ldur x8, [sp, #4]
        str x8, [x19]
        .cfi_def_cfa wsp, 96
        ldp x29, x30, [sp, #80]
        ldp x20, x19, [sp, #64]
        ldp x22, x21, [sp, #48]
        ldp x24, x23, [sp, #32]
        ldp x26, x25, [sp, #16]
        add sp, sp, #96
        .cfi_def_cfa_offset 0
        .cfi_restore w30
        .cfi_restore w29
        .cfi_restore w19
        .cfi_restore w20
        .cfi_restore w21
        .cfi_restore w22
        .cfi_restore w23
        .cfi_restore w24
        .cfi_restore w25
        .cfi_restore w26
        ret
        .loh AdrpAdd    Lloh6, Lloh7
```

Thanks for the support in advance ❤️ 